### PR TITLE
perf: optimize raster role logos (381 KB -> ~1.5 KB)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -69,6 +69,15 @@ interface Role {
   end: string | { label: string; dateTime: string }
 }
 
+// The logo set mixes raster (PNG) and vector (SVG) sources. next/image can only
+// optimize the raster ones: it returns HTTP 400 for SVG unless `dangerouslyAllowSVG`
+// is enabled, so SVGs must opt out of the optimizer individually.
+function isSvgSource(src: ImageProps['src']) {
+  const url =
+    typeof src === 'string' ? src : 'default' in src ? src.default.src : src.src
+  return url.endsWith('.svg')
+}
+
 function Role({ role }: { role: Role }) {
   let startLabel =
     typeof role.start === 'string' ? role.start : role.start.label
@@ -82,7 +91,13 @@ function Role({ role }: { role: Role }) {
     <li className="flex gap-4">
       <div className="relative mt-1 flex h-10 w-10 flex-none items-center justify-center rounded-full shadow-md shadow-zinc-800/5 ring-1 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0">
         <div className="h-7 w-7 overflow-hidden rounded-full">
-          <Image src={role.logo} alt="" unoptimized />
+          <Image
+            src={role.logo}
+            alt=""
+            width={28}
+            height={28}
+            unoptimized={isSvgSource(role.logo)}
+          />
         </div>
       </div>
       <dl className="flex flex-auto flex-wrap gap-x-2">


### PR DESCRIPTION
## Problem

The work-history logos on the home page render through `<Image ... unoptimized />` (`src/app/page.tsx`), which bypasses the Next.js image optimizer completely. Measured over the wire on the live site:

| Asset | Delivered | Intrinsic | Rendered at |
|---|---|---|---|
| `expressScriptsLogo.png` | **381,657 B** | 880x880 | 28x28 CSS px |
| `attLogo.svg` | 108,544 B gzip | 400x400 | 28x28 CSS px |
| `graceLogo.svg` | 21,873 B gzip | 400x400 | 28x28 CSS px |

That is ~500 KB, roughly 80% of the home page's total weight, to paint three 28-pixel circles. The PNG also decodes to ~2.95 MB of bitmap memory on the main thread to fill 3.1 KB of pixels.

## Evidence for the fix

Requesting the same PNG through this site's own optimizer, at the size it is actually displayed:

```
GET /_next/image?url=%2F_next%2Fstatic%2Fmedia%2FexpressScriptsLogo.73805680.png&w=64&q=75
-> 200, 1,550 bytes, image/webp
```

**381,657 -> 1,550 bytes. A 246x reduction.**

## Why `unoptimized` could not just be deleted

The same `<Image>` renders both raster and vector logos, and `next/image` returns **HTTP 400** for SVG sources unless `dangerouslyAllowSVG` is enabled (verified against the live optimizer). Removing the flag outright would have broken the two SVG logos.

So the flag is now applied **per source**: SVGs still opt out, raster images get optimized. Explicit `width`/`height` at the rendered size also make the generated `srcset` offer 32w/64w candidates instead of 880w/1920w.

## Not covered here

The two SVGs are auto-traced bitmaps (`attLogo.svg` is a single path with a **265,621-character** `d` attribute). They still ship unoptimized because fixing them means replacing the source assets, not changing this code. Worth a follow-up.

## Verification

- `tsc --noEmit` - 0 errors
- `next build` - exit 0
- `next lint --max-warnings=0` - clean

No visual change: the logos render at the same 28x28 size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)