### PR TITLE
a11y: fix 5 WCAG AA contrast failures (light + dark mode)

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -125,11 +125,11 @@ export default function Login() {
             </div>
           </form>
 
-          <p className="mt-10 text-center text-sm text-gray-500">
+          <p className="mt-10 text-center text-sm text-gray-500 dark:text-gray-400">
             Dont have an account?{' '}
             <a
               href="/signup"
-              className="font-semibold leading-6 text-indigo-600 hover:text-indigo-500"
+              className="font-semibold leading-6 text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
             >
               Signup
             </a>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -5,7 +5,7 @@ export default function NotFound() {
   return (
     <Container className="flex h-full items-center pt-16 sm:pt-32">
       <div className="flex flex-col items-center">
-        <p className="text-base font-semibold text-zinc-400 dark:text-zinc-500">
+        <p className="text-base font-semibold text-zinc-500 dark:text-zinc-400">
           404
         </p>
         <h1 className="mt-4 text-4xl font-bold tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -96,7 +96,7 @@ function Role({ role }: { role: Role }) {
         </dd>
         <dt className="sr-only">Date</dt>
         <dd
-          className="ml-auto text-xs text-zinc-400 dark:text-zinc-500"
+          className="ml-auto text-xs text-zinc-500 dark:text-zinc-400"
           aria-label={`${startLabel} until ${endLabel}`}
         >
           <time dateTime={startDate}>{startLabel}</time>{' '}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -57,7 +57,7 @@ export default async function ProjectGallery() {
               <Card.Description>{project.description}</Card.Description>
             </div>
             {project.label && (
-              <p className="relative z-10 mt-6 flex text-sm font-medium text-zinc-400 transition group-hover:text-teal-500 dark:text-zinc-200">
+              <p className="relative z-10 mt-6 flex text-sm font-medium text-zinc-500 transition group-hover:text-teal-700 dark:text-zinc-200 dark:group-hover:text-teal-400">
                 <LinkIcon className="h-6 w-6 flex-none" />
                 <span className="ml-2">{project.label}</span>
               </p>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -154,11 +154,11 @@ export default function Signup() {
             </div>
           </form>
 
-          <p className="mt-10 text-center text-sm text-gray-500">
+          <p className="mt-10 text-center text-sm text-gray-500 dark:text-gray-400">
             Already have an account?{' '}
             <a
               href="/login"
-              className="font-semibold leading-6 text-indigo-600 hover:text-indigo-500"
+              className="font-semibold leading-6 text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
             >
               Login
             </a>

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -96,7 +96,7 @@ Card.Cta = function CardCta({ children }: { children: React.ReactNode }) {
   return (
     <div
       aria-hidden="true"
-      className="relative z-10 mt-4 flex items-center text-sm font-medium text-teal-500"
+      className="relative z-10 mt-4 flex items-center text-sm font-medium text-teal-700 dark:text-teal-400"
     >
       {children}
       <ChevronRightIcon className="ml-1 h-4 w-4 stroke-current" />
@@ -120,7 +120,7 @@ Card.Eyebrow = function CardEyebrow<T extends React.ElementType = 'p'>({
     <Component
       className={clsx(
         className,
-        'relative z-10 order-first mb-3 flex items-center text-sm text-zinc-400 dark:text-zinc-500',
+        'relative z-10 order-first mb-3 flex items-center text-sm text-zinc-500 dark:text-zinc-400',
         decorate && 'pl-3.5',
       )}
       {...props}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -15,7 +15,7 @@ function NavLink({
   return (
     <Link
       href={href}
-      className="transition hover:text-teal-500 dark:hover:text-teal-400"
+      className="transition hover:text-teal-700 dark:hover:text-teal-400"
     >
       {children}
     </Link>
@@ -42,7 +42,7 @@ export function Footer() {
                   <Link
                     href="/"
                     onClick={() => setUser(null)}
-                    className="border-0 border-transparent bg-transparent transition hover:text-teal-500 dark:hover:text-teal-400"
+                    className="border-0 border-transparent bg-transparent transition hover:text-teal-700 dark:hover:text-teal-400"
                   >
                     Logout
                   </Link>
@@ -51,7 +51,7 @@ export function Footer() {
                   <NavLink href="/login">Login</NavLink>
                 </div>
               </div>
-              <p className="text-sm text-zinc-400 dark:text-zinc-500">
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">
                 &copy; {new Date().getFullYear()} DeRon Sutton. All rights
                 reserved.
               </p>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -161,8 +161,8 @@ function NavItem({
         className={clsx(
           'relative block px-3 py-2 transition',
           isActive
-            ? 'text-teal-500 dark:text-teal-400'
-            : 'hover:text-teal-500 dark:hover:text-teal-400',
+            ? 'text-teal-700 dark:text-teal-400'
+            : 'hover:text-teal-700 dark:hover:text-teal-400',
         )}
       >
         {children}


### PR DESCRIPTION
## Problem

Five distinct WCAG 2.1 AA contrast failures affecting text on **every page, in both themes**. Measured two ways that agree to within 0.02: axe-core injected into real Chrome against the live site, and computed numerically from the Tailwind v3 palette.

All affected text is 13-16px normal weight, so the 3:1 large-text exemption does not apply — the bar is **4.5:1**.

### Light mode

| Element | Before | After |
|---|---|---|
| Muted text on white (`text-zinc-400`) | **2.56:1** ❌ | `text-zinc-500` — **4.83:1** ✅ |
| Muted text on zinc-50 | **2.46:1** ❌ | `text-zinc-500` — **4.63:1** ✅ |
| Active nav + card CTA (`text-teal-500`) | **2.49:1** ❌ | `text-teal-700` — **5.47:1** ✅ |

### Dark mode

| Element | Before | After |
|---|---|---|
| Muted text on zinc-900 (`dark:text-zinc-500`) | **3.67:1** ❌ | `dark:text-zinc-400` — **6.91:1** ✅ |
| Muted text on black | **4.35:1** ❌ | `dark:text-zinc-400` — **8.19:1** ✅ |

(Two backgrounds because the `bg-white dark:bg-zinc-900` panel is `fixed inset-0` — viewport height only — so content below the fold sits on the body's `dark:bg-black`.)

### Login / signup

These two pages were written **light-mode-only**, with no `dark:` variants at all:

| Element | Before | After |
|---|---|---|
| Helper text (`text-gray-500`) | **3.66:1** ❌ | `dark:text-gray-400` — **6.98:1** ✅ |
| Signup/Login cross-link (`text-indigo-600`) | **2.82:1** ❌ | `dark:text-indigo-400` — **5.94:1** ✅ |

The cross-link is the only way to navigate between the two pages and was the worst offender on the site.

## One note worth flagging

`teal-600` is the obvious next step up from `teal-500`, but it measures **3.74:1** on white — it *still fails* AA for normal-weight text. `teal-700` (5.47:1) is the first value that actually passes. Dark mode already passed with `teal-400` (9.52:1) and is left unchanged.

## Scope

Affected text includes every experience/resume date, the footer copyright, the 404 label, the active nav indicator, card CTAs, and the auth-page links. Several of these classes are inherited from the Tailwind UI Spotlight template rather than hand-written — but they ship on the live site either way.

## Verification

- `tsc --noEmit` - 0 errors
- `next build` - exit 0
- `next lint --max-warnings=0` - clean

Colour-only change; no layout or markup is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)