### PR TITLE
fix: login and signup fail silently

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -14,22 +14,29 @@ export default function Login() {
   const [errorMessage, setErrorMessage] = useState('')
   const [showSuccess, setShowSuccess] = useState(false)
   const [showError, setShowError] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const router = useRouter()
 
-  const handleLogin = async () => {
-    if (email && password) {
-      await login({ email, password }).then((response) => {
-        if (response) {
-          loginUser(response)
-          setUser(response)
-          setSuccessMessage('Logged In Successfully')
-          setTimeout(() => {
-            router.push('/')
-          }, 1000)
-        } else {
-          setErrorMessage('Invalid Credentials')
-        }
-      })
+  const handleLogin = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (!email || !password) return
+
+    setIsSubmitting(true)
+    try {
+      const response = await login({ email, password })
+      loginUser(response)
+      setUser(response)
+      setSuccessMessage('Logged In Successfully')
+      setTimeout(() => {
+        router.push('/')
+      }, 1000)
+    } catch (error) {
+      // `login()` rejects on any non-2xx response. Without this catch the
+      // rejection was unhandled and a failed sign-in produced no feedback at all.
+      setErrorMessage(
+        error instanceof Error ? error.message : 'Invalid Credentials',
+      )
+      setIsSubmitting(false)
     }
   }
 
@@ -70,7 +77,7 @@ export default function Login() {
         </div>
 
         <div className="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
-          <form className="space-y-6">
+          <form className="space-y-6" onSubmit={handleLogin}>
             <div>
               <label
                 htmlFor="email"
@@ -116,11 +123,11 @@ export default function Login() {
             </div>
             <div>
               <button
-                onClick={handleLogin}
-                type="button"
-                className="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                type="submit"
+                disabled={isSubmitting}
+                className="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:cursor-not-allowed disabled:opacity-60"
               >
-                Sign in
+                {isSubmitting ? 'Signing in...' : 'Sign in'}
               </button>
             </div>
           </form>

--- a/src/app/services.tsx
+++ b/src/app/services.tsx
@@ -217,6 +217,20 @@ export const getUserById = async (userId: string) => {
   return response.json()
 }
 
+// The auth endpoints return a JSON body of the form `{ error: string }` on
+// failure (e.g. "User not found", "Invalid password"). Surface that instead of
+// collapsing every failure into one generic string, so callers can show the
+// user why the request actually failed.
+async function errorFromResponse(response: Response, fallback: string) {
+  try {
+    const body = await response.json()
+    if (body && typeof body.error === 'string') return new Error(body.error)
+  } catch {
+    // Body was not JSON; fall through to the generic message.
+  }
+  return new Error(fallback)
+}
+
 export const signup = async (user: any) => {
   const response = await fetch(createApiUrl(`/api/users?path=signup`), {
     method: 'POST',
@@ -226,7 +240,7 @@ export const signup = async (user: any) => {
     body: JSON.stringify(user),
   })
   if (!response.ok) {
-    throw new Error('Failed to sign up')
+    throw await errorFromResponse(response, 'Failed to sign up')
   }
   return response.json()
 }
@@ -240,7 +254,7 @@ export const login = async (credentials: any) => {
     body: JSON.stringify(credentials),
   })
   if (!response.ok) {
-    throw new Error('Failed to log in')
+    throw await errorFromResponse(response, 'Failed to log in')
   }
   return response.json()
 }

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -15,26 +15,33 @@ export default function Signup() {
   const [errorMessage, setErrorMessage] = useState('')
   const [showSuccess, setShowSuccess] = useState(false)
   const [showError, setShowError] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const router = useRouter()
 
-  const handleSignup = async () => {
-    if (email && password) {
-      if (password == passwordConfirmation) {
-        await signup({ email, password, isAdmin }).then((response) => {
-          if (response) {
-            console.log(response)
-            setUser(response)
-            setSuccessMessage('Signed Up Successfully')
-            setTimeout(() => {
-              router.push('/')
-            }, 1000)
-          } else {
-            setErrorMessage('Error Creating Account')
-          }
-        })
-      } else {
-        setErrorMessage('Passwords do not match')
-      }
+  const handleSignup = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (!email || !password) return
+
+    if (password !== passwordConfirmation) {
+      setErrorMessage('Passwords do not match')
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      const response = await signup({ email, password, isAdmin })
+      setUser(response)
+      setSuccessMessage('Signed Up Successfully')
+      setTimeout(() => {
+        router.push('/')
+      }, 1000)
+    } catch (error) {
+      // `signup()` rejects on any non-2xx response. Without this catch the
+      // rejection was unhandled and a failed signup produced no feedback at all.
+      setErrorMessage(
+        error instanceof Error ? error.message : 'Error Creating Account',
+      )
+      setIsSubmitting(false)
     }
   }
 
@@ -76,7 +83,7 @@ export default function Signup() {
         </div>
 
         <div className="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
-          <form className="space-y-6">
+          <form className="space-y-6" onSubmit={handleSignup}>
             <div>
               <label
                 htmlFor="email"
@@ -145,11 +152,11 @@ export default function Signup() {
 
             <div>
               <button
-                onClick={handleSignup}
-                type="button"
-                className="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                type="submit"
+                disabled={isSubmitting}
+                className="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:cursor-not-allowed disabled:opacity-60"
               >
-                Signup
+                {isSubmitting ? 'Creating account...' : 'Signup'}
               </button>
             </div>
           </form>


### PR DESCRIPTION
## Problem

**A failed sign-in currently produces no feedback whatsoever** — no message, no spinner change, no state change. This is the most user-visible bug I found on the site.

Two compounding defects in `handleLogin` (and the identical `handleSignup`):

**1. No `.catch()`.** `login()` throws on any non-2xx response (`services.tsx`), but the handler only chained `.then()`. A wrong password therefore became an **unhandled promise rejection**.

**2. The error branch was unreachable:**

```jsx
await login({ email, password }).then((response) => {
  if (response) { ...success... }
  else { setErrorMessage('Invalid Credentials') }   // <- can never run
})
```

`response` is parsed JSON from a 2xx response, so it is always truthy. `'Invalid Credentials'` could never render.

Combined with the site having no `aria-live` regions, a failed login is silent for sighted **and** screen-reader users.

## Also fixed

- **Forms could not be submitted with Enter.** The `<form>` had no `onSubmit` and the button was `type="button"`, so the HTML implicit-submission algorithm never fired (2 text fields, 0 submit buttons). This also meant the `required` attributes on the inputs **never validated**. Now `onSubmit` + `type="submit"`, restoring both.
- **Double-submit.** No in-flight state, so double-clicking fired two signups. Buttons now disable and show pending text.
- **Error detail was discarded.** The API returns `{ error: "User not found" }` / `{ error: "Invalid password" }`; the client collapsed every failure into one generic string, making a 400 and a 500 indistinguishable. A small `errorFromResponse` helper now reads the server's message.
- Removed a `console.log` of the signup response.

## Verification

- `tsc --noEmit` - 0 errors
- `next build` - exit 0
- `next lint --max-warnings=0` - clean

## Note

The 1-second `setTimeout` redirect on success is left as-is to keep this diff focused; it has no cleanup on unmount, which is worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)