### PR TITLE
a11y: announce async results, fix error icon, remove empty headings

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -42,7 +42,7 @@ interface SuccessNotificationProps {
 
 function SuccessNotification({ message, onClose }: SuccessNotificationProps) {
   return (
-    <div className="fixed bottom-8 right-8 rounded-md bg-green-50 p-4 dark:bg-green-900">
+    <div role="status" className="fixed bottom-8 right-8 rounded-md bg-green-50 p-4 dark:bg-green-900">
       <div className="flex">
         <div className="flex-shrink-0">
           <CheckCircleIcon className="h-5 w-5 text-green-400" aria-hidden="true" />
@@ -74,7 +74,7 @@ interface ErrorNotificationProps {
 
 function ErrorNotification({ message, onClose }: ErrorNotificationProps) {
   return (
-    <div className="fixed bottom-8 right-8 rounded-md bg-red-50 p-4 dark:bg-red-900">
+    <div role="alert" className="fixed bottom-8 right-8 rounded-md bg-red-50 p-4 dark:bg-red-900">
       <div className="flex">
         <div className="flex-shrink-0">
           <XCircleIcon className="h-5 w-5 text-red-400" aria-hidden="true" />

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -13,7 +13,9 @@ function Section({ section }: { section: Section }) {
     <article className="md:grid md:grid-cols-4 md:items-baseline">
       <Card className="md:col-span-3">
         <Card.Title>{section.header}</Card.Title>
-        <Card.Subtitle>{section.subHeader}</Card.Subtitle>
+        {section.subHeader && (
+          <Card.Subtitle>{section.subHeader}</Card.Subtitle>
+        )}
         {section.contents.map((content, index) => (
           <Card.Description key={index}>{content.content}</Card.Description>
         ))}

--- a/src/components/Alerts.tsx
+++ b/src/components/Alerts.tsx
@@ -1,8 +1,8 @@
-import { CheckCircleIcon } from '@heroicons/react/20/solid'
+import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/20/solid'
 
 export function SuccessNotification({ message }: { message: string }) {
   return (
-    <div className="rounded-md bg-green-50 p-4">
+    <div role="status" className="rounded-md bg-green-50 p-4">
       <div className="flex">
         <div className="flex-shrink-0">
           <CheckCircleIcon
@@ -23,13 +23,10 @@ export function SuccessNotification({ message }: { message: string }) {
 
 export function ErrorNotification({ message }: { message: string }) {
   return (
-    <div className="rounded-md bg-red-50 p-4">
+    <div role="alert" className="rounded-md bg-red-50 p-4">
       <div className="flex">
         <div className="flex-shrink-0">
-          <CheckCircleIcon
-            className="h-5 w-5 text-red-400"
-            aria-hidden="true"
-          />
+          <XCircleIcon className="h-5 w-5 text-red-400" aria-hidden="true" />
         </div>
         <div className="ml-3">
           <h3 className="text-sm font-medium text-red-800">Error</h3>


### PR DESCRIPTION
Three small, independent accessibility fixes.

## 1. Async results were never announced to screen readers

There is currently **no `aria-live` region or `role="status"`/`role="alert"` anywhere in the app** — verified by grepping all 8 rendered pages and all of `src/`:

```
home/resume/experience/projects/login/signup/admin/404:  ariaLive=0  role_status_or_alert=0
```

So every success and error toast is silent for screen-reader users — including `"Invalid Credentials"` on `/login` and every admin CRUD result. Compounding it, the toasts auto-dismiss after 3 seconds and render at the very end of the DOM, far from the control that triggered them, so there is no way to discover them after the fact.

Adds `role="status"` (polite) to success and `role="alert"` (assertive) to errors, in both the shared `Alerts` components and the admin page's own local copies.

Fails **WCAG 4.1.3 Status Messages (AA)**.

> Pairs with #9 — that PR makes failed logins produce a message at all; this one makes it audible.

## 2. The error alert showed a green success checkmark

```jsx
export function ErrorNotification(...) {
  ...
  <CheckCircleIcon className="h-5 w-5 text-red-400" aria-hidden="true" />
```

Copy-pasted from `SuccessNotification` with only the colour class changed, so errors on `/login` and `/signup` display a **checkmark**. `XCircleIcon` was already imported correctly and used correctly in the admin page's own copy of this component.

## 3. Three empty `<h3>` elements on /resume

`Card.Subtitle` rendered unconditionally, so sections with no `subHeader` — "Development", "College", "Online" — emitted:

```html
<h3 class="text-sm italic text-zinc-600 dark:text-zinc-400"></h3>
```

Confirmed by axe-core's `empty-heading` rule (3 nodes). Users navigating by heading landed on nameless stops. Now rendered only when a subheader exists.

## Verification

- `tsc --noEmit` - 0 errors
- `next build` - exit 0
- `next lint --max-warnings=0` - clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)