### PR TITLE
ci: add Lighthouse CI with accessibility and resource budgets

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,41 @@
+name: Lighthouse
+
+# Audits the DEPLOYED site, so this reports regressions after a deploy rather
+# than blocking them before merge.
+#
+# To gate pull requests instead, the job would need to build the app and serve
+# it locally - which needs a MongoDB instance, because the content pages are
+# `force-dynamic` and query the database on every request. That is a bigger
+# change; see the PR description.
+on:
+  workflow_dispatch: # run on demand from the Actions tab
+  schedule:
+    - cron: '0 13 * * 1' # Mondays, 13:00 UTC
+  push:
+    branches: [main]
+    # Only re-audit when something that can affect the rendered page changes.
+    paths:
+      - 'src/**'
+      - 'next.config.mjs'
+      - 'tailwind.config.ts'
+      - 'package.json'
+      - 'lighthouserc.js'
+      - '.github/workflows/lighthouse.yml'
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # Give the deploy a moment to finish when this is triggered by a push.
+      - name: Wait for deploy
+        if: github.event_name == 'push'
+        run: sleep 60
+
+      - name: Run Lighthouse CI
+        run: npx --yes @lhci/cli@0.15.1 autorun --config=./lighthouserc.js

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -53,10 +53,10 @@ module.exports = {
         'heading-order': 'error',
         'bypass': 'error',
 
-        // ---- Accessibility: currently FAILING -> warn for now -----------
-        // color-contrast is fixed by PR #8 (5 WCAG AA failures). Flip it to
-        // 'error' once that lands - that ratchet is the point of this file.
-        'color-contrast': 'warn',
+        // Fixed by PR #8 and verified live (text-zinc-500 / text-teal-700 /
+        // dark: variants on the auth pages are all deployed), so this is now
+        // a hard error to keep it fixed.
+        'color-contrast': 'error',
 
         // Overall category score. Starts as a warning because the exact
         // number has not been observed on a CI runner yet; once you see it in
@@ -64,13 +64,24 @@ module.exports = {
         'categories:accessibility': ['warn', { minScore: 1 }],
 
         // ---- Resource budgets: deterministic, hard failures -------------
-        // Ceilings set just above today's measured over-the-wire numbers so
-        // the build is green on day one. Tighten as PRs land - see the table
-        // in the PR description for the target values.
-        'resource-summary:script:size': ['error', { maxNumericValue: 200000 }],
-        'resource-summary:stylesheet:size': ['error', { maxNumericValue: 25000 }],
-        'resource-summary:image:size': ['error', { maxNumericValue: 550000 }],
-        'resource-summary:total:size': ['error', { maxNumericValue: 800000 }],
+        // Ceilings set ~15-20% above the live over-the-wire numbers measured
+        // after PR #7 shipped, so there is room for normal change but not for
+        // another 380 KB regression.
+        //
+        //   measured live          budget
+        //   images    133,721 B -> 160,000
+        //   scripts   114,752 B -> 140,000
+        //   stylesheet  8,486 B ->  15,000
+        //   total     264,953 B -> 320,000
+        //
+        // The image number is still dominated by two auto-traced SVG logos
+        // (attLogo 108,544 B + graceLogo 21,873 B gzip). Replacing those with
+        // hand-authored vectors should let the image budget drop to ~20,000
+        // and the total to ~160,000.
+        'resource-summary:script:size': ['error', { maxNumericValue: 140000 }],
+        'resource-summary:stylesheet:size': ['error', { maxNumericValue: 15000 }],
+        'resource-summary:image:size': ['error', { maxNumericValue: 160000 }],
+        'resource-summary:total:size': ['error', { maxNumericValue: 320000 }],
 
         // ---- Timing: watch first, tighten later -------------------------
         'largest-contentful-paint': 'warn',

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,0 +1,96 @@
+/**
+ * Lighthouse CI configuration.
+ *
+ * Audits the deployed site and enforces accessibility + resource-size budgets.
+ *
+ * Two deliberate choices worth knowing about:
+ *
+ * 1. Timing metrics (LCP / CLS / TBT) are set to "warn", not "error".
+ *    Lighthouse timing scores depend on the CPU and network of the machine
+ *    running them, and a GitHub-hosted runner is both slower and noisier than
+ *    a laptop. Hard-failing on them before observing real runner variance
+ *    produces flaky builds. Watch them for a few runs, then tighten.
+ *
+ * 2. Accessibility audits and byte budgets ARE hard errors, because they are
+ *    deterministic - the same markup and the same bytes produce the same
+ *    result on any machine.
+ */
+module.exports = {
+  ci: {
+    collect: {
+      url: [
+        'https://portfolio.dsuttonserver.net/',
+        'https://portfolio.dsuttonserver.net/resume',
+        'https://portfolio.dsuttonserver.net/experience',
+        'https://portfolio.dsuttonserver.net/projects',
+        'https://portfolio.dsuttonserver.net/login',
+        'https://portfolio.dsuttonserver.net/signup',
+      ],
+      numberOfRuns: 3,
+      settings: {
+        // Lighthouse's own default throttling, applied consistently so runs
+        // are comparable to each other over time.
+        preset: 'desktop',
+      },
+    },
+    assert: {
+      assertions: {
+        // ---- Accessibility: deterministic, hard failures ----------------
+        // These currently PASS. Asserting them locks in the current state so
+        // a regression fails the build.
+        'html-has-lang': 'error',
+        'image-alt': 'error',
+        'link-name': 'error',
+        'button-name': 'error',
+        'document-title': 'error',
+        'meta-viewport': 'error',
+        'list': 'error',
+        'listitem': 'error',
+        'aria-allowed-attr': 'error',
+        'aria-required-attr': 'error',
+        'aria-valid-attr-value': 'error',
+        'label': 'error',
+        'heading-order': 'error',
+        'bypass': 'error',
+
+        // ---- Accessibility: currently FAILING -> warn for now -----------
+        // color-contrast is fixed by PR #8 (5 WCAG AA failures). Flip it to
+        // 'error' once that lands - that ratchet is the point of this file.
+        'color-contrast': 'warn',
+
+        // Overall category score. Starts as a warning because the exact
+        // number has not been observed on a CI runner yet; once you see it in
+        // the first run, set a real minScore and make it an error.
+        'categories:accessibility': ['warn', { minScore: 1 }],
+
+        // ---- Resource budgets: deterministic, hard failures -------------
+        // Ceilings set just above today's measured over-the-wire numbers so
+        // the build is green on day one. Tighten as PRs land - see the table
+        // in the PR description for the target values.
+        'resource-summary:script:size': ['error', { maxNumericValue: 200000 }],
+        'resource-summary:stylesheet:size': ['error', { maxNumericValue: 25000 }],
+        'resource-summary:image:size': ['error', { maxNumericValue: 550000 }],
+        'resource-summary:total:size': ['error', { maxNumericValue: 800000 }],
+
+        // ---- Timing: watch first, tighten later -------------------------
+        'largest-contentful-paint': 'warn',
+        'cumulative-layout-shift': 'warn',
+        'total-blocking-time': 'warn',
+        'unused-javascript': 'warn',
+        'modern-image-formats': 'warn',
+        'uses-responsive-images': 'warn',
+
+        // Not useful signal for this site; silence rather than ignore.
+        'csp-xss': 'off',
+        'errors-in-console': 'off',
+        'unsized-images': 'off',
+      },
+    },
+    upload: {
+      // Publishes each report to Google's temporary public storage and prints
+      // a shareable URL in the job log. Reports expire after a few days.
+      // The audited site is already public, so nothing private is exposed.
+      target: 'temporary-public-storage',
+    },
+  },
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lighthouse": "npx --yes @lhci/cli@0.15.1 autorun --config=./lighthouserc.js"
   },
   "browserslist": "defaults, not ie <= 11",
   "dependencies": {


### PR DESCRIPTION
## Why

The home page says:

> "I specialize in building high-quality websites and applications with a focus on **performance, accessibility**, and user experience."

Nothing in the repo checked either one — which is how a **381,657-byte logo** rendered at 28x28px and **five WCAG AA contrast failures** shipped unnoticed. This adds the guardrail that keeps #7–#10 from silently regressing.

## What this is

- **Lighthouse** — Google's page auditor (the DevTools "Lighthouse" tab). Loads each page in headless Chrome with simulated throttling and scores Performance / Accessibility / Best Practices / SEO.
- **Lighthouse CI** (`@lhci/cli`) — runs it in CI, medians 3 runs to cut noise, and **fails the build** on a violated assertion. Lighthouse's accessibility category is powered by **axe-core**, so the a11y assertions are axe rules.

## Budgets are set from live measurements taken after #7–#10 deployed

| Resource | Measured live | Budget | Was (pre-#7) |
|---|---|---|---|
| Images | **133,721 B** | 160,000 | 512,074 B |
| Scripts (gzip) | 114,752 B | 140,000 | — |
| Stylesheet (gzip) | 8,486 B | 15,000 | — |
| **Total** | **264,953 B** | 320,000 | **643,193 B** |

**Page weight is down 2.4x.** The 880x880 PNG now serves at **1,559 bytes** through the optimizer — within 9 bytes of the 1,550 predicted in #7.

Budgets sit ~15–20% above actual: room for normal change, none for another 380 KB regression.

## What it enforces

**Hard errors — accessibility** (deterministic axe rules, all currently passing):

`color-contrast` · `image-alt` · `link-name` · `button-name` · `label` · `list` · `listitem` · `heading-order` · `bypass` · `html-has-lang` · `document-title` · `meta-viewport` · `aria-allowed-attr` · `aria-required-attr` · `aria-valid-attr-value`

`color-contrast` is a hard error rather than a warning because I verified #8 is deployed — `text-zinc-500`, `text-teal-700`, and the `dark:` variants on the auth pages are all present in the served HTML.

**Warnings for now:** LCP, CLS, TBT, `unused-javascript`, `modern-image-formats`, `uses-responsive-images`, and the overall accessibility category score.

## Two deliberate design decisions

**1. Timing metrics are warnings, not errors.** Lighthouse timing scores depend on the CPU and network of the machine running them, and a GitHub-hosted runner is slower and noisier than a laptop. Hard-failing before observing real runner variance produces flaky builds people learn to ignore. Watch a few runs, then set real thresholds.

**2. It audits the deployed site, not a PR build** — so it *detects* regressions post-deploy rather than *blocking* them pre-merge. Gating PRs properly would mean building and serving the app in CI **with a MongoDB instance**, because every content page is `force-dynamic` and queries the DB on each request; a local `next start` with no DB returns a 500 and Lighthouse would happily audit the error page. Worth a follow-up, and it gets much easier if those pages move to ISR.

## Next tightening step

Remaining image weight is almost entirely two auto-traced SVG logos — `attLogo.svg` (108,544 B gzip; a single path with a **265,621-character** `d` attribute) and `graceLogo.svg` (21,873 B). Replacing them with hand-authored vectors should drop the image budget to ~20,000 and the total to ~160,000.

## Honest caveats

- **I could not execute Lighthouse locally to pre-verify the assertion list** — Chromium can't authenticate through this environment's egress proxy. The byte budgets are from direct `curl` measurement and are solid; the a11y assertion list is from audits I verified against your live site. **Treat the first CI run as the real baseline** — if something I expected to pass doesn't, it's a one-line adjustment and genuine signal, not a broken config.
- Reports upload to `temporary-public-storage` and print a shareable URL in the job log; they expire after a few days. The site is already public, but swap `upload.target` if you'd rather not.
- Automated tooling catches roughly a third of real accessibility problems. This stops regressions; it doesn't replace manual keyboard and screen-reader testing. Case in point: axe **did not** catch the duplicate `id="title"` bug on `/admin`, because it deprecated its duplicate-id rules in v4.10.

## Try it

Merge, then **Actions → Lighthouse → Run workflow**. Or locally: `npm run lighthouse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)