### PR TITLE
content: reframe projects page around what was built, not what was learned

### DIFF
--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -27,8 +27,8 @@ export default async function ProjectGallery() {
   let projects = await getAllProjects()
   return (
     <SimpleLayout
-      title="Things I've made trying to put my mark on the world."
-      intro="I've worked on many different projects over the years but these are the ones that I'm most proud of. Each one has taught me something new and has helped me grow as a developer."
+      title="Things I've designed, built, and shipped."
+      intro="A mix of client work and systems I've built end to end - what each one does, and how it's put together."
     >
       <ul
         role="list"


### PR DESCRIPTION
Acting on mentor feedback: *"most proud of"* / *"taught me something new"* / *"helped me grow as a developer"* is learning-log framing. At a few years in, the question a reader is answering is **what you built and what it does**.

## The change

**Before**
> **Things I've made trying to put my mark on the world.**
> I've worked on many different projects over the years but these are the ones that I'm most proud of. Each one has taught me something new and has helped me grow as a developer.

**After**
> **Things I've designed, built, and shipped.**
> A mix of client work and systems I've built end to end — what each one does, and how it's put together.

Copy-only; no markup or layout touched.

## One deliberate restraint

I scoped the new intro to what the page **actually delivers today**. It would have been easy to write something about constraints, trade-offs, and decisions — it reads better — but the project entries currently describe what each system is and how it's built, nothing more. Promising case studies in the intro when the entries aren't case studies is the same overclaiming problem your mentor flagged, just relocated.

That copy should land only if the entries themselves get rewritten.

## Which brings up the bigger issue

The intro is the smaller half of this problem. **The project entries themselves are the part that undercuts you**, and they live in the database rather than this repo. Two of the four are actively working against you:

- **Portfolio-API-Dotnet** — *"I wanted to get some more experience with setting up .NET projects from the ground up"* — pure learning framing. The repo is also an in-memory EF Core scaffold that cannot persist data.
- **Portfolio-API-Node** — an orphaned service nothing has called since commit `1aa2fa5`, which stores and compares passwords in plaintext.

My recommendation is to **cut both from the projects page**. Two strong entries beat four where half invite a bad first impression. Suggested replacement copy for the ones that stay is in my message.

## Verification

- `next build` — exit 0
- `tsc --noEmit` — 0 errors
- `next lint --max-warnings=0` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)