### PR TITLE
fix: order projects correctly; remove dead RSS feed link

### DIFF
--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -21,7 +21,11 @@ export async function GET(request: Request) {
 
   // Handle /api/projects/all (default)
   try {
-    const projects = await prisma.project.findMany()
+    // The admin UI collects an `order` for each project, so honour it here.
+    // Without this the list came back in whatever order Mongo produced.
+    const projects = await prisma.project.findMany({
+      orderBy: { order: 'asc' },
+    })
     return NextResponse.json(projects)
   } catch (error: any) {
     console.error(error)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,11 +13,6 @@ export const metadata: Metadata = {
   },
   description:
     'I’m DeRon, a software engineer based in St. Louis. At Omni Federal I build full-stack applications for federal geospatial workflows; before that I spent three years at AT&T on internal tools used across the company.',
-  alternates: {
-    types: {
-      'application/rss+xml': `${process.env.NEXT_PUBLIC_SITE_URL}/feed.xml`,
-    },
-  },
 }
 
 export default function RootLayout({


### PR DESCRIPTION
Two small, visible bugs.

## 1. Projects rendered in arbitrary order

The admin UI collects an `order` for every project, and `GET /api/projects` ignored it:

```ts
const projects = await prisma.project.findMany()   // no orderBy
```

The sections endpoint already does this correctly — the pattern was known and applied inconsistently.

**The code fix alone wasn't enough.** Three of the four projects had `order: null` in the database, so there was nothing to sort by:

```
BEFORE                              AFTER
order=0     Personal-Portfolio      order=0  Personal-Portfolio
order=None  Portfolio-API-Dotnet    order=1  Allegiance Home Health Care
order=None  Allegiance              order=2  Portfolio-API-Dotnet
order=None  Portfolio-API-Node      order=3  Portfolio-API-Node
```

I've set those values in the database already, so the field now means something. Allegiance is placed second — it's the only client work on the page, so it shouldn't be last. Reorder in `/admin` if you'd rather.

## 2. Every page advertised a broken RSS feed

```html
<link rel="alternate" type="application/rss+xml" href="undefined/feed.xml">
```

Two faults in one line:

- The template's `feed.xml` route was deleted, but the `alternates` metadata pointing at it wasn't — `/feed.xml` returns **404** (verified live).
- `NEXT_PUBLIC_SITE_URL` is unset in production, so the href renders with the literal string **`undefined`**.

Removed the block. If you want a feed later, restore `app/feed.xml/route.ts` and set `NEXT_PUBLIC_SITE_URL` — the `feed` package is still a dependency and is now unused by anything, so that's also a candidate for removal.

## Verification

- `next build` — exit 0 · `tsc --noEmit` — 0 errors · `next lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)