### PR TITLE
a11y: unique form ids, page titles, h1s, skip link, reduced motion

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,16 @@
+import { type Metadata } from 'next'
+
+// The page itself is a client component and cannot export metadata, so the
+// title is set here. Without this, /admin inherited the generic site-wide
+// title and was indistinguishable from every other page (WCAG 2.4.2).
+export const metadata: Metadata = {
+  title: 'Admin',
+}
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return <>{children}</>
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -612,6 +612,7 @@ export default function AdminActions() {
                   <span>{experience.title}</span>
                   <button
                     onClick={() => handleEditExperience(experience)}
+                    aria-label={`Edit ${experience.title}`}
                     className="w-32 px-3 py-2 text-sm font-semibold text-zinc-900 dark:text-zinc-100 hover:underline bg-transparent border-none shadow-none"
                   >
                     Edit
@@ -622,12 +623,12 @@ export default function AdminActions() {
             {(editingExperienceId || showAddExperienceForm) && (
               <form onSubmit={showAddExperienceForm ? handleExperienceSubmit : handleEditingExperienceSubmit} className="mt-6 space-y-4">
                 <div>
-                  <label htmlFor="title" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                  <label htmlFor="experience-title" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
                     Title
                   </label>
                   <input
                     type="text"
-                    id="title"
+                    id="experience-title"
                     value={showAddExperienceForm ? experienceTitle : editingExperienceTitle}
                     onChange={(e) => showAddExperienceForm ? setExperienceTitle(e.target.value) : setEditingExperienceTitle(e.target.value)}
                     className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
@@ -724,6 +725,7 @@ export default function AdminActions() {
                   <span>{project.name}</span>
                   <button
                     onClick={() => handleEditProject(project)}
+                    aria-label={`Edit ${project.name}`}
                     className="w-32 px-3 py-2 text-sm font-semibold text-zinc-900 dark:text-zinc-100 hover:underline bg-transparent border-none shadow-none"
                   >
                     Edit
@@ -861,6 +863,7 @@ export default function AdminActions() {
                   <span className="flex-1">{header.header}</span>
                   <button
                     onClick={() => handleEditSection(header)}
+                    aria-label={`Edit ${header.header}`}
                     className="w-32 px-3 py-2 text-sm font-semibold text-zinc-900 dark:text-zinc-100 hover:underline bg-transparent border-none shadow-none"
                   >
                     Edit
@@ -871,12 +874,12 @@ export default function AdminActions() {
             {(editingSectionId || showAddSectionForm) && (
               <form onSubmit={showAddSectionForm ? handleSectionSubmit : handleEditingSectionSubmit} className="mt-6 space-y-4">
                 <div>
-                  <label htmlFor="title" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                  <label htmlFor="section-title" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
                     Title
                   </label>
                   <input
                     type="text"
-                    id="title"
+                    id="section-title"
                     value={showAddSectionForm ? sectionTitle : editingSectionTitle}
                     onChange={(e) => showAddSectionForm ? setSectionTitle(e.target.value) : setEditingSectionTitle(e.target.value)}
                     className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"

--- a/src/app/login/layout.tsx
+++ b/src/app/login/layout.tsx
@@ -1,0 +1,16 @@
+import { type Metadata } from 'next'
+
+// The page itself is a client component and cannot export metadata, so the
+// title is set here. Without this, /login inherited the generic site-wide
+// title and was indistinguishable from every other page (WCAG 2.4.2).
+export const metadata: Metadata = {
+  title: 'Sign in',
+}
+
+export default function LoginLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return <>{children}</>
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -71,9 +71,9 @@ export default function Login() {
           {showError && <ErrorNotification message={errorMessage} />}
         </div>
         <div className="sm:mx-auto sm:w-full sm:max-w-sm">
-          <h2 className="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900 dark:text-white">
+          <h1 className="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900 dark:text-white">
             Sign in to your account
-          </h2>
+          </h1>
         </div>
 
         <div className="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">

--- a/src/app/signup/layout.tsx
+++ b/src/app/signup/layout.tsx
@@ -1,0 +1,16 @@
+import { type Metadata } from 'next'
+
+// The page itself is a client component and cannot export metadata, so the
+// title is set here. Without this, /signup inherited the generic site-wide
+// title and was indistinguishable from every other page (WCAG 2.4.2).
+export const metadata: Metadata = {
+  title: 'Create an account',
+}
+
+export default function SignupLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return <>{children}</>
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -77,9 +77,9 @@ export default function Signup() {
           {showError && <ErrorNotification message={errorMessage} />}
         </div>
         <div className="sm:mx-auto sm:w-full sm:max-w-sm">
-          <h2 className="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900 dark:text-white">
+          <h1 className="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900 dark:text-white">
             Signup for an account
-          </h2>
+          </h1>
         </div>
 
         <div className="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -9,9 +9,17 @@ export function Layout({ children }: { children: React.ReactNode }) {
           <div className="w-full bg-white ring-1 ring-zinc-100 dark:bg-zinc-900 dark:ring-zinc-300/20" />
         </div>
       </div>
+      <a
+        href="#main"
+        className="sr-only rounded-md bg-zinc-900 px-4 py-2 text-sm font-semibold text-white focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 dark:bg-zinc-100 dark:text-zinc-900"
+      >
+        Skip to content
+      </a>
       <div className="relative flex w-full flex-col">
         <Header />
-        <main className="flex-auto">{children}</main>
+        <main id="main" tabIndex={-1} className="flex-auto">
+          {children}
+        </main>
         <Footer />
       </div>
     </>

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -2,3 +2,19 @@
 @import 'tailwindcss/components';
 @import './prism.css';
 @import 'tailwindcss/utilities';
+
+/*
+ * Respect the OS "reduce motion" setting. Applied globally rather than as
+ * per-element motion-reduce: variants so that transitions added later are
+ * covered by default instead of needing to be remembered each time.
+ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  ::before,
+  ::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
Six accessibility failures. Your home page now says *"I care about performance and accessibility, and I measure both rather than assuming"* — these are the ones that most directly undercut that sentence.

## 1. Duplicate `id="title"` — WCAG Level A

The Experience form and the Section form on `/admin` both used `id="title"`, and neither closes the other, so **both can be open at once**. When they are, the browser resolves *both* `<label for="title">` to the first input, and the second field has **no accessible name at all**. Clicking the Section "Title" label also focuses the Experience input.

Verified at runtime earlier via the browser's own `HTMLInputElement.labels`:

```json
{"duplicateIds":[["title",["INPUT","INPUT"]]],
 "labelControls":["I0","I0"],
 "input1_labels":[],
 "conclusion":"SECOND #title INPUT HAS NO ACCESSIBLE NAME"}
```

Now `experience-title` / `section-title`. Fails WCAG 1.3.1, 3.3.2 and 4.1.2.

> **Worth knowing:** axe does **not** catch this — its duplicate-id rules were deprecated in v4.10 — so the Lighthouse CI from #13 would never have flagged it. This is the concrete case for why automated checks aren't sufficient on their own.

## 2. Fifteen buttons all named "Edit" — WCAG 2.4.6

Each row's title sat in a sibling `<span>` with no programmatic association, so a screen-reader user pulling up the elements list saw fifteen indistinguishable "Edit" buttons across three entity types. Each now carries `aria-label={`Edit ${name}`}`.

## 3. No `<h1>` on /login or /signup

Both jumped straight to `<h2>`, leaving no top-level heading to navigate to. Promoted.

## 4. Generic page titles — WCAG 2.4.2 Level A

`/login`, `/signup` and `/admin` all served `"DeRon Sutton - Full Stack Software Developer"`. They're client components and can't export `metadata`, so each gets a small route `layout.tsx` that does.

| Route | Before | After |
|---|---|---|
| `/login` | DeRon Sutton - Full Stack Software Developer | **Sign in** |
| `/signup` | *(same)* | **Create an account** |
| `/admin` | *(same)* | **Admin** |

## 5. No skip link

Keyboard users passed **eight header stops** before reaching content on every page. Adds a focus-visible skip link, and gives `<main>` an `id` and `tabIndex={-1}` so focus actually lands there.

## 6. No `prefers-reduced-motion` handling

Zero occurrences in the entire shipped stylesheet. Added as a **global rule** rather than per-element `motion-reduce:` variants, so transitions added later are covered by default instead of relying on someone remembering each time.

## Deliberately not changed

The **scroll-linked avatar transform** in `Header.tsx`. It *positions* the avatar rather than decorating it, so neutralising it under reduced-motion would break the header layout rather than calm it. Flagging rather than silently doing the wrong thing.

Also unaddressed: the **404 route** still has a generic title. `not-found.tsx` can't export metadata in the App Router, so it needs a different approach — small and separable.

## Verification (in the built output, not just source)

```
<title>Sign in - DeRon Sutton</title>
<h1 ...>Sign in to your account</h1>
Skip to content
id="main"
prefers-reduced-motion  -> present in compiled CSS
duplicate ids in admin  -> none
```

`next build` exit 0 · `tsc --noEmit` 0 errors · `next lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)