### PR TITLE
chore: real README, remove dead code, make the linter catch it in future

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,14 @@
+# MongoDB connection string. Must point at a replica set - Prisma's MongoDB
+# connector uses transactions for every write, and MongoDB only supports those
+# on a replica set. A single-node replica set is sufficient.
+DATABASE_URL="mongodb://localhost:27017/portfolio?replicaSet=rs0&directConnection=true"
+
+# Public origin of the site. Used for absolute URLs.
 NEXT_PUBLIC_SITE_URL=https://example.com
+
+# Base URL used for server-side API calls. Defaults to localhost when unset.
+NEXT_PUBLIC_APP_URL=
+
+# Umami analytics (optional - the script tag is skipped when unset).
+NEXT_PUBLIC_UMAMI_SCRIPT_URL=
+NEXT_PUBLIC_UMAMI_WEBSITE_ID=

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,16 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrors": "none"
+      }
+    ]
+  },
+  "plugins": [
+    "@typescript-eslint"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -1,42 +1,108 @@
-# Spotlight
+# Personal Portfolio
 
-Spotlight is a [Tailwind UI](https://tailwindui.com) site template built using [Tailwind CSS](https://tailwindcss.com) and [Next.js](https://nextjs.org).
+The source for [portfolio.dsuttonserver.net](https://portfolio.dsuttonserver.net) — a
+Next.js site whose content is stored in MongoDB and edited through a built-in
+admin panel rather than by redeploying.
+
+Built on the [Tailwind UI "Spotlight"](https://tailwindui.com) template.
+
+## Stack
+
+| | |
+|---|---|
+| Framework | Next.js 14 (App Router) |
+| Language | TypeScript |
+| Styling | Tailwind CSS |
+| Data | MongoDB via Prisma |
+| Deployment | Docker |
+
+## Requirements
+
+- Node.js 20
+- A MongoDB instance **running as a replica set**
+
+> The replica set is not optional. Prisma's MongoDB connector wraps every write
+> in a transaction, and MongoDB only supports transactions on a replica set.
+> Against a standalone `mongod`, reads work but every create and update fails
+> with `Prisma needs to perform transactions...`, which presents as the admin
+> panel silently refusing to save. A single-node replica set is sufficient.
 
 ## Getting started
 
-To get started with this template, first install the npm dependencies:
-
 ```bash
 npm install
-```
-
-Next, create a `.env.local` file in the root of your project and set the `NEXT_PUBLIC_SITE_URL` variable to your site's public URL:
-
-```
-NEXT_PUBLIC_SITE_URL=https://example.com
-```
-
-Next, run the development server:
-
-```bash
+cp .env.example .env        # then fill in DATABASE_URL
+npx prisma generate
 npm run dev
 ```
 
-Finally, open [http://localhost:3000](http://localhost:3000) in your browser to view the website.
+Open <http://localhost:3000>.
 
-## Customizing
+## Environment variables
 
-You can start editing this template by modifying the files in the `/src` folder. The site will auto-update as you edit these files.
+| Variable | Required | Purpose |
+|---|---|---|
+| `DATABASE_URL` | **yes** | MongoDB connection string |
+| `NEXT_PUBLIC_SITE_URL` | no | Public origin, used for absolute URLs |
+| `NEXT_PUBLIC_APP_URL` | no | Base URL for server-side API calls |
+| `NEXT_PUBLIC_UMAMI_SCRIPT_URL` | no | Umami analytics script |
+| `NEXT_PUBLIC_UMAMI_WEBSITE_ID` | no | Umami site id |
+
+## Scripts
+
+| Command | Does |
+|---|---|
+| `npm run dev` | Development server |
+| `npm run build` | Production build (runs lint and type checking) |
+| `npm start` | Serve a production build |
+| `npm run lint` | ESLint |
+| `npm run typecheck` | `tsc --noEmit` |
+| `npm run lighthouse` | Lighthouse CI against the deployed site |
+
+## Content
+
+Page content lives in MongoDB, not in the repo:
+
+| Model | Drives |
+|---|---|
+| `Section` | `/resume` — grouped by `title` into Skills / Experience / Education |
+| `Experience` | `/experience` and the cards on the home page |
+| `Project` | `/projects` |
+| `User` | Admin login |
+
+Edit it at `/admin`. `scripts/apply-content-updates.mjs` applies a batch of
+content changes in one command and supports `--dry-run`.
+
+The work history on the home page is the exception — it is hard-coded in
+`src/app/page.tsx`.
+
+## Project layout
+
+```
+src/
+  app/            routes; api/ holds the route handlers
+  components/     shared UI (much of it from the Spotlight template)
+  lib/            data access helpers and types
+  images/         logos and avatar
+  styles/         Tailwind entry point
+prisma/           schema
+scripts/          one-off maintenance scripts
+```
+
+## Quality checks
+
+`next build` runs ESLint and TypeScript, so a type error or lint failure breaks
+the build rather than shipping.
+
+Two GitHub Actions workflows run on top of that:
+
+- **CI** — lint, typecheck and build on every pull request.
+- **Lighthouse** — audits the deployed site against accessibility assertions and
+  resource-size budgets defined in `lighthouserc.js`.
+
+There is currently no automated test suite.
 
 ## License
 
-This site template is a commercial product and is licensed under the [Tailwind UI license](https://tailwindui.com/license).
-
-## Learn more
-
-To learn more about the technologies used in this site template, see the following resources:
-
-- [Tailwind CSS](https://tailwindcss.com/docs) - the official Tailwind CSS documentation
-- [Next.js](https://nextjs.org/docs) - the official Next.js documentation
-- [Headless UI](https://headlessui.dev) - the official Headless UI documentation
-- [MDX](https://mdxjs.com) - the MDX documentation
+This site is built on the Tailwind UI Spotlight template, which is covered by
+the [Tailwind UI license](https://tailwindui.com/license). See `LICENSE.md`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "typescript": "^5.3.3"
       },
       "devDependencies": {
+        "@typescript-eslint/eslint-plugin": "^6.21.0",
         "eslint": "^8.56.0",
         "eslint-config-next": "^14.0.4",
         "prettier": "^3.1.1",
@@ -1266,8 +1267,7 @@
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "peer": true
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -1329,6 +1329,13 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
     },
+    "node_modules/@types/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/unist": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
@@ -1338,6 +1345,92 @@
       "version": "1.18.4",
       "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.18.4.tgz",
       "integrity": "sha512-I6e+9+HtWADAWeeJWDFQtdk4EVSAbj6Rtz4q8fJ7mSr1M0jzlFcs8/HZ+Xb5SHzVm1dxH7aUiI+A8kA8Gcrm0A=="
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
+      "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/type-utils": "6.21.0",
+        "@typescript-eslint/utils": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "6.18.1",
@@ -1382,6 +1475,121 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
+      "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/utils": "6.21.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/types": {
@@ -1439,6 +1647,137 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
       "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tailwindui-template",
+  "name": "personal-portfolio",
   "version": "0.1.0",
   "private": true,
   "scripts": {
@@ -43,6 +43,7 @@
     "typescript": "^5.3.3"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
     "eslint": "^8.56.0",
     "eslint-config-next": "^14.0.4",
     "prettier": "^3.1.1",

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -3,7 +3,6 @@
 import { SimpleLayout } from '@/components/SimpleLayout'
 import { useState, useEffect } from 'react'
 import {
-  getSections,
   createSection,
   updateSection,
   deleteSection,
@@ -15,25 +14,10 @@ import {
   createExperience,
   updateExperience,
   deleteExperience,
-  getExperiences,
-  getUsers,
-  updateUser,
-  changeUserRole,
-  getContents,
-  createContent,
-  updateContent,
-  deleteContent,
-  getSectionById
+  getExperiences
 } from '../services'
-import { Header, Content } from '@/lib/resume'
-import { Fragment } from 'react'
-import { Menu, Transition } from '@headlessui/react'
-import { ChevronDownIcon } from '@heroicons/react/20/solid'
+import { Header } from '@/lib/resume'
 import { CheckCircleIcon, XMarkIcon, XCircleIcon } from '@heroicons/react/24/outline'
-
-function classNames(...classes: any) {
-  return classes.filter(Boolean).join(' ')
-}
 
 interface SuccessNotificationProps {
   message: string
@@ -111,7 +95,6 @@ export default function AdminActions() {
   const [sectionContent2, setSectionContent2] = useState('')
   const [sectionContent3, setSectionContent3] = useState('')
 
-  const [editingContents, setEditingContents] = useState<Content[]>([])
   const [editingSectionId, setEditingSectionId] = useState('')
   const [editingSectionTitle, setEditingSectionTitle] = useState('')
   const [editingSectionOrder, setEditingSectionOrder] = useState('')
@@ -129,7 +112,6 @@ export default function AdminActions() {
   const [projectLogo, setProjectLogo] = useState('')
 
   const [headers, setHeaders] = useState<Header[]>([])
-  const [selectedHeader, setSelectedHeader] = useState<Header | null>(null)
   const [successMessage, setSuccessMessage] = useState('')
   const [errorMessage, setErrorMessage] = useState('')
   const [showSuccess, setShowSuccess] = useState(false)
@@ -153,9 +135,6 @@ export default function AdminActions() {
   const [projects, setProjects] = useState<any[]>([])
 
   // Add mode state variables
-  const [isAddingSection, setIsAddingSection] = useState(false)
-  const [isAddingExperience, setIsAddingExperience] = useState(false)
-  const [isAddingProject, setIsAddingProject] = useState(false)
 
   const [showAddExperienceForm, setShowAddExperienceForm] = useState(false)
   const [showAddProjectForm, setShowAddProjectForm] = useState(false)
@@ -175,7 +154,6 @@ export default function AdminActions() {
         setEditingSectionContent1(data.contents?.[0]?.content || '')
         setEditingSectionContent2(data.contents?.[1]?.content || '')
         setEditingSectionContent3(data.contents?.[2]?.content || '')
-        setEditingContents(data.contents?.map((c: any) => ({ id: c.id, order: c.order })) || [])
       })
       .catch((error) => {
         console.error('Error fetching section:', error)
@@ -203,7 +181,7 @@ export default function AdminActions() {
     }
 
     await createExperience(requestBody)
-      .then((response) => {
+      .then(() => {
         setSuccessMessage('Experience added successfully')
         clearAddExperienceForm()
       })
@@ -236,7 +214,7 @@ export default function AdminActions() {
     }
 
     await createSection(requestBody)
-      .then((response) => {
+      .then(() => {
         setSuccessMessage('Section added successfully')
         clearAddSectionForm()
         getSectionHeaders().then((response) => {
@@ -267,7 +245,7 @@ export default function AdminActions() {
     }
 
     await createProject(requestBody)
-      .then((response) => {
+      .then(() => {
         setSuccessMessage('Project added successfully')
         clearAddProjectForm()
       })
@@ -275,21 +253,6 @@ export default function AdminActions() {
         setErrorMessage('Error adding project')
         console.error('Error:', error)
       })
-  }
-
-  const handleDropdownSelection = async (header: Header) => {
-    await getSectionById(header.id).then((response) => {
-      setEditingSectionId(response?.id || '')
-      setEditingSectionTitle(response?.title || '')
-      setEditingSectionOrder(String(response?.order || ''))
-      setEditingSectionHeader(response?.header || '')
-      setEditingSectionSubHeader(response?.subHeader || '')
-      setEditingContents(response?.contents || [])
-      setEditingSectionContent1(response?.contents?.[0]?.content || '')
-      setEditingSectionContent2(response?.contents?.[1]?.content || '')
-      setEditingSectionContent3(response?.contents?.[2]?.content || '')
-    })
-    setSelectedHeader(header)
   }
 
   const handleEditingSectionSubmit = async (event: React.FormEvent) => {
@@ -311,7 +274,7 @@ export default function AdminActions() {
     }
 
     await updateSection(editingSectionId, requestBody)
-      .then((response) => {
+      .then(() => {
         setSuccessMessage('Section updated successfully')
         clearEditingSection()
         getSectionHeaders().then((response) => {
@@ -320,25 +283,6 @@ export default function AdminActions() {
       })
       .catch((error) => {
         setErrorMessage('Error updating section')
-        console.error('Error:', error)
-      })
-  }
-
-  const handleDelete = async () => {
-    if (!editingSectionId) {
-      setErrorMessage('Section must be selected to delete')
-      return
-    }
-    await deleteSection(editingSectionId)
-      .then((response) => {
-        setSuccessMessage('Section deleted successfully')
-        clearEditingSection()
-        getSectionHeaders().then((response) => {
-          setHeaders(response)
-        })
-      })
-      .catch((error) => {
-        setErrorMessage('Error deleting section')
         console.error('Error:', error)
       })
   }
@@ -410,7 +354,7 @@ export default function AdminActions() {
     }
 
     await updateExperience(editingExperienceId, requestBody)
-      .then((response) => {
+      .then(() => {
         setSuccessMessage('Experience updated successfully')
         clearEditingExperience()
         fetchExperiences()
@@ -458,7 +402,7 @@ export default function AdminActions() {
     }
 
     await updateProject(editingProjectId, requestBody)
-      .then((response) => {
+      .then(() => {
         setSuccessMessage('Project updated successfully')
         clearEditingProject()
         fetchProjects()

--- a/src/app/api/sections/[id]/route.ts
+++ b/src/app/api/sections/[id]/route.ts
@@ -53,7 +53,7 @@ export async function PATCH(
     const { title, order, header, subHeader, content1, content2, content3 } = body
 
     // First update the section
-    const section = await prisma.section.update({
+    await prisma.section.update({
       where: {
         id: params.id,
       },

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -103,8 +103,6 @@ export async function POST(request: Request) {
 export async function PATCH(request: Request) {
   const { searchParams } = new URL(request.url)
   const id = searchParams.get('id')
-  const path = searchParams.get('path')
-
   if (!id) {
     return NextResponse.json({ error: 'ID is required' }, { status: 400 })
   }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -7,7 +7,7 @@ import { useRouter } from 'next/navigation'
 import { loginUser } from '@/lib/auth'
 
 export default function Login() {
-  const { user, setUser } = useContext(UserContext)
+  const { setUser } = useContext(UserContext)
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [successMessage, setSuccessMessage] = useState('')

--- a/src/app/services.tsx
+++ b/src/app/services.tsx
@@ -1,5 +1,3 @@
-import axios from 'axios'
-
 // Helper function to get the base URL
 const getBaseUrl = () => {
   if (typeof window !== 'undefined') {

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -8,7 +8,7 @@ import { useRouter } from 'next/navigation'
 export default function Signup() {
   const { setUser } = useContext(UserContext)
   const [email, setEmail] = useState('')
-  const [isAdmin, setIsAdmin] = useState(false)
+  const [isAdmin] = useState(false)
   const [password, setPassword] = useState('')
   const [passwordConfirmation, setPasswordConfirmation] = useState('')
   const [successMessage, setSuccessMessage] = useState('')


### PR DESCRIPTION
## 1. README

The repo's front page was still the unmodified Tailwind UI **"Spotlight"** template README — describing a template, not this site. No mention that content lives in MongoDB, that `DATABASE_URL` is required, that `prisma generate` must run, or that there's an admin panel. **Following it produced a non-booting app.**

Rewritten for the actual project: stack, setup, environment variables, scripts, where content lives, project layout, and what CI enforces.

It also documents the **replica-set requirement** — the thing that cost us a round trip this week, because it isn't obvious and presents as the admin panel silently refusing to save rather than as an error anyone sees.

`.env.example` documented **1 of the 5** environment variables the code reads. Now all five. And `package.json` no longer claims to be `"tailwindui-template"`.

## 2. Dead code

Removed from `admin/page.tsx`:

- `Fragment`, `Menu`, `Transition`, `ChevronDownIcon` imports — leftovers of a Headless UI dropdown replaced by a plain list
- `classNames()` — defined, never called
- `handleDropdownSelection()` — superseded by `handleEditSection`
- `handleDelete()` — superseded by `handleDeleteSection`
- `isAddingSection` / `isAddingExperience` / `isAddingProject` — never read
- `editingContents` — written twice, never read
- `selectedHeader` / `setSelectedHeader` — never read
- 9 unused service imports, 6 unused `response` params

**1002 → 946 lines.**

Plus the dead `import axios` in `services.tsx` (flagged in the original audit — the file has used `fetch` throughout), an unused `path` variable, an unused destructured `user`, an unused Prisma result assignment, and an unused `setIsAdmin`.

## 3. The durable part

None of that was caught because `.eslintrc.json` was only `"next/core-web-vitals"`, which doesn't enable `no-unused-vars`. **Without this, the cleanup just drifts back.**

Enabling it needed `@typescript-eslint/eslint-plugin`, which `eslint-config-next` does *not* ship — only the parser. Pinned to `^6` to match the parser version `eslint-config-next@14` depends on; `^8` fails to resolve:

```
Conflicting peer dependency: @typescript-eslint/parser@8.69.0
  @typescript-eslint/parser@"^5.4.2 || ^6.0.0" from eslint-config-next@14.0.4
```

Since #11 re-enabled linting during builds, dead code now **fails the build** instead of accumulating.

## One correction worth flagging

Replacing `.then((response) =>` with `.then(() =>` across the file was too broad. ESLint flagged **6** unused params, but there were **9** occurrences — the other three genuinely use `response`. `tsc` caught it and they're restored.

Worth mentioning because it's the argument for running all three checks rather than trusting the linter alone: lint passed on the broken version, types didn't.

## Deliberately not in this PR

Two items from the same bucket that are real work, not cleanup:

- **Splitting the 946-line admin component.** Still four unrelated domains and ~45 `useState` in one function. A refactor that large with **no tests** is exactly the change most likely to break something silently.
- **A test suite.** Still zero tests. Worth doing properly rather than bolted onto a chore PR — and it makes the refactor above safe.

Happy to take either next; I didn't want to bury them in a cleanup PR.

## Verification

`next build` exit 0 · `tsc --noEmit` 0 errors · `next lint --max-warnings=0` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)