### PR TITLE
refactor: extract ExperienceManager out of the admin page

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -10,13 +10,10 @@ import {
   createProject,
   updateProject,
   deleteProject,
-  getProjects,
-  createExperience,
-  updateExperience,
-  deleteExperience,
-  getExperiences
+  getProjects
 } from '../services'
 import { Header } from '@/lib/resume'
+import { ExperienceManager } from '@/components/admin/ExperienceManager'
 import { CheckCircleIcon, XMarkIcon, XCircleIcon } from '@heroicons/react/24/outline'
 
 interface SuccessNotificationProps {
@@ -84,9 +81,6 @@ function ErrorNotification({ message, onClose }: ErrorNotificationProps) {
 }
 
 export default function AdminActions() {
-  const [experienceTitle, setExperienceTitle] = useState('')
-  const [experienceDate, setExperienceDate] = useState('')
-  const [experienceContent, setExperienceContent] = useState('')
   const [sectionTitle, setSectionTitle] = useState('')
   const [sectionOrder, setSectionOrder] = useState('')
   const [sectionHeader, setSectionHeader] = useState('')
@@ -118,11 +112,6 @@ export default function AdminActions() {
   const [showError, setShowError] = useState(false)
 
   // Add new state variables for editing experiences
-  const [editingExperienceId, setEditingExperienceId] = useState('')
-  const [editingExperienceTitle, setEditingExperienceTitle] = useState('')
-  const [editingExperienceDate, setEditingExperienceDate] = useState('')
-  const [editingExperienceContent, setEditingExperienceContent] = useState('')
-  const [experiences, setExperiences] = useState<any[]>([])
 
   // Add new state variables for editing projects
   const [editingProjectId, setEditingProjectId] = useState('')
@@ -136,7 +125,6 @@ export default function AdminActions() {
 
   // Add mode state variables
 
-  const [showAddExperienceForm, setShowAddExperienceForm] = useState(false)
   const [showAddProjectForm, setShowAddProjectForm] = useState(false)
   const [showAddSectionForm, setShowAddSectionForm] = useState(false)
 
@@ -157,37 +145,6 @@ export default function AdminActions() {
       })
       .catch((error) => {
         console.error('Error fetching section:', error)
-      })
-  }
-
-  const handleExperienceSubmit = async (event: React.FormEvent) => {
-    event.preventDefault()
-
-    if (!experienceTitle || !experienceDate || !experienceContent) {
-      setErrorMessage('All fields are required')
-      return
-    }
-
-    const dateRegex = /^\d{4}-\d{2}-\d{2}$/
-    if (!dateRegex.test(experienceDate)) {
-      setErrorMessage('Invalid date format')
-      return
-    }
-
-    let requestBody = {
-      title: experienceTitle,
-      date: experienceDate,
-      content: experienceContent,
-    }
-
-    await createExperience(requestBody)
-      .then(() => {
-        setSuccessMessage('Experience added successfully')
-        clearAddExperienceForm()
-      })
-      .catch((error) => {
-        setErrorMessage('Error adding experience')
-        console.error('Error:', error)
       })
   }
 
@@ -308,12 +265,6 @@ export default function AdminActions() {
     setSectionContent3('')
   }
 
-  const clearAddExperienceForm = () => {
-    setExperienceTitle('')
-    setExperienceDate('')
-    setExperienceContent('')
-  }
-
   const clearAddProjectForm = () => {
     setProjectName('')
     setProjectDescription('')
@@ -321,55 +272,6 @@ export default function AdminActions() {
     setProjectLabel('')
     setProjectOrder('')
     setProjectLogo('')
-  }
-
-  // Add new handlers for editing experiences
-  const handleEditExperience = (experience: any) => {
-    setShowAddExperienceForm(false)
-    clearAddExperienceForm()
-    setEditingExperienceId(experience.id)
-    setEditingExperienceTitle(experience.title)
-    setEditingExperienceDate(experience.date)
-    setEditingExperienceContent(experience.content)
-  }
-
-  const handleEditingExperienceSubmit = async (event: React.FormEvent) => {
-    event.preventDefault()
-
-    if (!editingExperienceTitle || !editingExperienceDate || !editingExperienceContent) {
-      setErrorMessage('All fields are required')
-      return
-    }
-
-    const dateRegex = /^\d{4}-\d{2}-\d{2}$/
-    if (!dateRegex.test(editingExperienceDate)) {
-      setErrorMessage('Invalid date format')
-      return
-    }
-
-    let requestBody = {
-      title: editingExperienceTitle,
-      date: editingExperienceDate,
-      content: editingExperienceContent,
-    }
-
-    await updateExperience(editingExperienceId, requestBody)
-      .then(() => {
-        setSuccessMessage('Experience updated successfully')
-        clearEditingExperience()
-        fetchExperiences()
-      })
-      .catch((error) => {
-        setErrorMessage('Error updating experience')
-        console.error('Error:', error)
-      })
-  }
-
-  const clearEditingExperience = () => {
-    setEditingExperienceId('')
-    setEditingExperienceTitle('')
-    setEditingExperienceDate('')
-    setEditingExperienceContent('')
   }
 
   // Add new handlers for editing projects
@@ -424,15 +326,6 @@ export default function AdminActions() {
   }
 
   // Add fetch functions
-  const fetchExperiences = async () => {
-    try {
-      const response = await getExperiences()
-      setExperiences(response)
-    } catch (error) {
-      console.error('Error fetching experiences:', error)
-    }
-  }
-
   const fetchProjects = async () => {
     try {
       const response = await getProjects()
@@ -454,7 +347,6 @@ export default function AdminActions() {
 
   // Add useEffect to fetch data
   useEffect(() => {
-    fetchExperiences()
     fetchProjects()
   }, [])
 
@@ -486,19 +378,6 @@ export default function AdminActions() {
     }
   }, [errorMessage])
 
-  const handleDeleteExperience = async (id: string) => {
-    try {
-      await deleteExperience(id)
-      await fetchExperiences()
-      clearEditingExperience()
-      setShowSuccess(true)
-      setSuccessMessage('Experience deleted successfully!')
-    } catch (error) {
-      setShowError(true)
-      setErrorMessage('Failed to delete experience.')
-    }
-  }
-
   const handleDeleteProject = async (id: string) => {
     try {
       await deleteProject(id)
@@ -528,120 +407,11 @@ export default function AdminActions() {
   return (
     <SimpleLayout title="Admin" intro="">
       <div className="space-y-8">
-        {/* Edit Experience Section */}
-        <div className="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40">
-          <h2 className="flex text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-            Experience Management
-          </h2>
-          <div className="mt-6">
-            <div>
-              <div className="flex items-center justify-end px-3">
-                <button
-                  onClick={() => {
-                    setShowAddExperienceForm(true)
-                    clearAddExperienceForm()
-                  }}
-                  className="w-32 px-3 py-2 text-sm font-semibold text-zinc-900 dark:text-zinc-100 hover:underline bg-transparent border-none shadow-none"
-                >
-                  Create
-                </button>
-              </div>
-              {experiences.map((experience, index) => (
-                <div 
-                  key={experience.id} 
-                  className={`flex items-center justify-between px-3 ${
-                    index % 2 === 0 ? 'bg-zinc-50 dark:bg-zinc-800/50' : ''
-                  }`}
-                >
-                  <span>{experience.title}</span>
-                  <button
-                    onClick={() => handleEditExperience(experience)}
-                    aria-label={`Edit ${experience.title}`}
-                    className="w-32 px-3 py-2 text-sm font-semibold text-zinc-900 dark:text-zinc-100 hover:underline bg-transparent border-none shadow-none"
-                  >
-                    Edit
-                  </button>
-                </div>
-              ))}
-            </div>
-            {(editingExperienceId || showAddExperienceForm) && (
-              <form onSubmit={showAddExperienceForm ? handleExperienceSubmit : handleEditingExperienceSubmit} className="mt-6 space-y-4">
-                <div>
-                  <label htmlFor="experience-title" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Title
-                  </label>
-                  <input
-                    type="text"
-                    id="experience-title"
-                    value={showAddExperienceForm ? experienceTitle : editingExperienceTitle}
-                    onChange={(e) => showAddExperienceForm ? setExperienceTitle(e.target.value) : setEditingExperienceTitle(e.target.value)}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div>
-                  <label htmlFor="date" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Date (YYYY-MM-DD)
-                  </label>
-                  <input
-                    type="text"
-                    id="date"
-                    value={showAddExperienceForm ? experienceDate : editingExperienceDate}
-                    onChange={(e) => showAddExperienceForm ? setExperienceDate(e.target.value) : setEditingExperienceDate(e.target.value)}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div>
-                  <label htmlFor="content" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Content
-                  </label>
-                  <textarea
-                    id="content"
-                    value={showAddExperienceForm ? experienceContent : editingExperienceContent}
-                    onChange={(e) => showAddExperienceForm ? setExperienceContent(e.target.value) : setEditingExperienceContent(e.target.value)}
-                    rows={4}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div className="flex justify-between space-x-4">
-                  {editingExperienceId && (
-                    <button
-                      type="button"
-                      onClick={async () => {
-                        if (window.confirm('Are you sure you want to delete this experience?')) {
-                          await handleDeleteExperience(editingExperienceId)
-                        }
-                      }}
-                      className="rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-700"
-                    >
-                      Delete
-                    </button>
-                  )}
-                  <div className="flex space-x-4">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setShowAddExperienceForm(false)
-                        clearAddExperienceForm()
-                        clearEditingExperience()
-                      }}
-                      className="rounded-md bg-zinc-200 px-3 py-2 text-sm font-semibold text-zinc-900 shadow-sm hover:bg-zinc-300 dark:bg-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-600"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      type="submit"
-                      className="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
-                    >
-                      {showAddExperienceForm ? 'Add Experience' : 'Update Experience'}
-                    </button>
-                  </div>
-                </div>
-              </form>
-            )}
-          </div>
-        </div>
+        <ExperienceManager
+          onSuccess={setSuccessMessage}
+          onError={setErrorMessage}
+        />
 
-        {/* Edit Project Section */}
         <div className="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40">
           <h2 className="flex text-sm font-semibold text-zinc-900 dark:text-zinc-100">
             Project Management

--- a/src/components/admin/ExperienceManager.test.tsx
+++ b/src/components/admin/ExperienceManager.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const svc = vi.hoisted(() => ({
+  getExperiences: vi.fn(),
+  createExperience: vi.fn(),
+  updateExperience: vi.fn(),
+  deleteExperience: vi.fn(),
+}))
+vi.mock('@/app/services', () => svc)
+
+import { ExperienceManager } from './ExperienceManager'
+
+const ROWS = [
+  { id: '1', title: 'Shipped a thing', date: '2025-03-10', content: 'Details here' },
+  { id: '2', title: 'Shipped another', date: '2024-01-02', content: 'More details' },
+]
+
+const onSuccess = vi.fn()
+const onError = vi.fn()
+
+function setup() {
+  render(<ExperienceManager onSuccess={onSuccess} onError={onError} />)
+  return userEvent.setup()
+}
+
+async function fillForm(user: ReturnType<typeof userEvent.setup>, v: Record<string, string>) {
+  for (const [label, value] of Object.entries(v)) {
+    const el = screen.getByLabelText(new RegExp(label, 'i'))
+    await user.clear(el)
+    if (value) await user.type(el, value)
+  }
+}
+
+describe('ExperienceManager', () => {
+  beforeEach(() => {
+    onSuccess.mockReset()
+    onError.mockReset()
+    svc.getExperiences.mockReset().mockResolvedValue(ROWS)
+    svc.createExperience.mockReset().mockResolvedValue({})
+    svc.updateExperience.mockReset().mockResolvedValue({})
+    svc.deleteExperience.mockReset().mockResolvedValue({})
+  })
+
+  it('lists existing experiences on mount', async () => {
+    setup()
+    expect(await screen.findByText('Shipped a thing')).toBeInTheDocument()
+    expect(screen.getByText('Shipped another')).toBeInTheDocument()
+  })
+
+  it('gives each row Edit button a distinguishing accessible name', async () => {
+    setup()
+    expect(await screen.findByRole('button', { name: 'Edit Shipped a thing' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit Shipped another' })).toBeInTheDocument()
+  })
+
+  it('creates an experience and refreshes the list', async () => {
+    const user = setup()
+    await screen.findByText('Shipped a thing')
+    await user.click(screen.getByRole('button', { name: 'Create' }))
+    await fillForm(user, { title: 'New one', 'date \\(yyyy': '2026-05-01', content: 'Body' })
+    await user.click(screen.getByRole('button', { name: 'Add Experience' }))
+
+    await waitFor(() =>
+      expect(svc.createExperience).toHaveBeenCalledWith({
+        title: 'New one', date: '2026-05-01', content: 'Body',
+      }),
+    )
+    expect(onSuccess).toHaveBeenCalledWith('Experience added successfully')
+    // Regression: the add path never re-fetched, so a newly created entry did
+    // not appear until a full page reload.
+    expect(svc.getExperiences).toHaveBeenCalledTimes(2)
+  })
+
+  it('opens the edit form prefilled and updates by id', async () => {
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Edit Shipped a thing' }))
+
+    expect(screen.getByLabelText(/title/i)).toHaveValue('Shipped a thing')
+    expect(screen.getByLabelText(/content/i)).toHaveValue('Details here')
+
+    await fillForm(user, { title: 'Renamed' })
+    await user.click(screen.getByRole('button', { name: 'Update Experience' }))
+
+    await waitFor(() =>
+      expect(svc.updateExperience).toHaveBeenCalledWith('1', {
+        title: 'Renamed', date: '2025-03-10', content: 'Details here',
+      }),
+    )
+    expect(onSuccess).toHaveBeenCalledWith('Experience updated successfully')
+  })
+
+  it('rejects empty fields without calling the API', async () => {
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Create' }))
+    await user.click(screen.getByRole('button', { name: 'Add Experience' }))
+
+    expect(onError).toHaveBeenCalledWith('All fields are required')
+    expect(svc.createExperience).not.toHaveBeenCalled()
+  })
+
+  it('rejects a malformed date', async () => {
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Create' }))
+    await fillForm(user, { title: 'T', 'date \\(yyyy': '05/01/2026', content: 'C' })
+    await user.click(screen.getByRole('button', { name: 'Add Experience' }))
+
+    expect(onError).toHaveBeenCalledWith('Invalid date format')
+    expect(svc.createExperience).not.toHaveBeenCalled()
+  })
+
+  it('reports an API failure instead of failing silently', async () => {
+    svc.createExperience.mockRejectedValue(new Error('boom'))
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Create' }))
+    await fillForm(user, { title: 'T', 'date \\(yyyy': '2026-05-01', content: 'C' })
+    await user.click(screen.getByRole('button', { name: 'Add Experience' }))
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith('Error adding experience'))
+  })
+
+  it('deletes only after the user confirms', async () => {
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Edit Shipped a thing' }))
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+    expect(svc.deleteExperience).not.toHaveBeenCalled()
+
+    confirm.mockReturnValue(true)
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+    await waitFor(() => expect(svc.deleteExperience).toHaveBeenCalledWith('1'))
+    expect(onSuccess).toHaveBeenCalledWith('Experience deleted successfully!')
+  })
+
+  it('closes the form on cancel', async () => {
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Create' }))
+    expect(screen.getByLabelText(/title/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.queryByLabelText(/title/i)).not.toBeInTheDocument()
+  })
+
+  it('does not leak values from an edit into a later create', async () => {
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Edit Shipped a thing' }))
+    expect(screen.getByLabelText(/title/i)).toHaveValue('Shipped a thing')
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    await user.click(screen.getByRole('button', { name: 'Create' }))
+    expect(screen.getByLabelText(/title/i)).toHaveValue('')
+  })
+})

--- a/src/components/admin/ExperienceManager.tsx
+++ b/src/components/admin/ExperienceManager.tsx
@@ -1,0 +1,217 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+import {
+  createExperience,
+  deleteExperience,
+  getExperiences,
+  updateExperience,
+} from '@/app/services'
+
+export interface AdminExperience {
+  id: string
+  title: string
+  date: string
+  content: string
+}
+
+/**
+ * Which form, if any, is open. Replaces the previous pair of parallel state
+ * sets (`experienceTitle` + `editingExperienceTitle`, and so on) that every
+ * input had to choose between with a ternary.
+ */
+type Mode = { kind: 'closed' } | { kind: 'add' } | { kind: 'edit'; id: string }
+
+const EMPTY = { title: '', date: '', content: '' }
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
+
+export function ExperienceManager({
+  onSuccess,
+  onError,
+}: {
+  onSuccess: (message: string) => void
+  onError: (message: string) => void
+}) {
+  const [experiences, setExperiences] = useState<AdminExperience[]>([])
+  const [mode, setMode] = useState<Mode>({ kind: 'closed' })
+  const [form, setForm] = useState(EMPTY)
+
+  const refresh = useCallback(async () => {
+    try {
+      setExperiences(await getExperiences())
+    } catch (error) {
+      console.error('Error fetching experiences:', error)
+    }
+  }, [])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const close = () => {
+    setMode({ kind: 'closed' })
+    setForm(EMPTY)
+  }
+
+  const field = (name: keyof typeof EMPTY) => ({
+    id: `experience-${name}`,
+    value: form[name],
+    onChange: (
+      e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    ) => setForm((f) => ({ ...f, [name]: e.target.value })),
+    className:
+      'mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm',
+  })
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (mode.kind === 'closed') return
+
+    if (!form.title || !form.date || !form.content) {
+      onError('All fields are required')
+      return
+    }
+    if (!ISO_DATE.test(form.date)) {
+      onError('Invalid date format')
+      return
+    }
+
+    const adding = mode.kind === 'add'
+    try {
+      if (adding) {
+        await createExperience(form)
+      } else {
+        await updateExperience(mode.id, form)
+      }
+      onSuccess(`Experience ${adding ? 'added' : 'updated'} successfully`)
+      close()
+      await refresh()
+    } catch (error) {
+      onError(`Error ${adding ? 'adding' : 'updating'} experience`)
+      console.error('Error:', error)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (mode.kind !== 'edit') return
+    if (!window.confirm('Are you sure you want to delete this experience?')) return
+
+    try {
+      await deleteExperience(mode.id)
+      close()
+      await refresh()
+      onSuccess('Experience deleted successfully!')
+    } catch (error) {
+      onError('Failed to delete experience.')
+    }
+  }
+
+  const buttonClass =
+    'w-32 px-3 py-2 text-sm font-semibold text-zinc-900 dark:text-zinc-100 hover:underline bg-transparent border-none shadow-none'
+
+  return (
+    <div className="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40">
+      <h2 className="flex text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+        Experience Management
+      </h2>
+      <div className="mt-6">
+        <div>
+          <div className="flex items-center justify-end px-3">
+            <button
+              onClick={() => {
+                setForm(EMPTY)
+                setMode({ kind: 'add' })
+              }}
+              className={buttonClass}
+            >
+              Create
+            </button>
+          </div>
+          {experiences.map((experience, index) => (
+            <div
+              key={experience.id}
+              className={`flex items-center justify-between px-3 ${
+                index % 2 === 0 ? 'bg-zinc-50 dark:bg-zinc-800/50' : ''
+              }`}
+            >
+              <span>{experience.title}</span>
+              <button
+                onClick={() => {
+                  setForm({
+                    title: experience.title,
+                    date: experience.date,
+                    content: experience.content,
+                  })
+                  setMode({ kind: 'edit', id: experience.id })
+                }}
+                aria-label={`Edit ${experience.title}`}
+                className={buttonClass}
+              >
+                Edit
+              </button>
+            </div>
+          ))}
+        </div>
+
+        {mode.kind !== 'closed' && (
+          <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+            <div>
+              <label
+                htmlFor="experience-title"
+                className="block text-sm font-medium text-zinc-900 dark:text-zinc-100"
+              >
+                Title
+              </label>
+              <input type="text" {...field('title')} />
+            </div>
+            <div>
+              <label
+                htmlFor="experience-date"
+                className="block text-sm font-medium text-zinc-900 dark:text-zinc-100"
+              >
+                Date (YYYY-MM-DD)
+              </label>
+              <input type="text" {...field('date')} />
+            </div>
+            <div>
+              <label
+                htmlFor="experience-content"
+                className="block text-sm font-medium text-zinc-900 dark:text-zinc-100"
+              >
+                Content
+              </label>
+              <textarea rows={4} {...field('content')} />
+            </div>
+            <div className="flex justify-between space-x-4">
+              {mode.kind === 'edit' && (
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  className="rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-700"
+                >
+                  Delete
+                </button>
+              )}
+              <div className="flex space-x-4">
+                <button
+                  type="button"
+                  onClick={close}
+                  className="rounded-md bg-zinc-200 px-3 py-2 text-sm font-semibold text-zinc-900 shadow-sm hover:bg-zinc-300 dark:bg-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-600"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+                >
+                  {mode.kind === 'add' ? 'Add Experience' : 'Update Experience'}
+                </button>
+              </div>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
> **Stacked on #22** (the test suite), since these tests need that infrastructure. Base is `test/add-vitest-suite` so the diff here stays reviewable — GitHub will retarget to `main` automatically once #22 merges.

First of three panel extractions. Everything experience-related moves out of `admin/page.tsx` into a self-contained component with its own state and tests.

```
admin/page.tsx   950 → 719 lines,   46 → 37 useState
```

Moved: 9 state declarations, 6 handlers, the mount fetch, and 113 lines of JSX.

## The main win: parallel state is gone

Every input previously had to pick between two variables with a ternary:

```jsx
value={showAddExperienceForm ? experienceTitle : editingExperienceTitle}
onChange={(e) => showAddExperienceForm
  ? setExperienceTitle(e.target.value)
  : setEditingExperienceTitle(e.target.value)}
```

That's now one `form` object plus a discriminated `mode`:

```ts
type Mode = { kind: 'closed' } | { kind: 'add' } | { kind: 'edit'; id: string }
```

Adding a field touches **one place instead of eight**, and the two `clearXxx()` helpers collapse into a single `close()`.

Notifications stay owned by the page — the component takes `onSuccess`/`onError` callbacks rather than reaching for toast state, so there's still one notification system rather than one per panel.

## One intentional behaviour change

Flagging this because everything else is a faithful move:

**The create path never re-fetched.** Update and delete both called `fetchExperiences()`; adding did not — so a newly created entry didn't appear until a full page reload. The extracted component refreshes after all three, and a test asserts `getExperiences` is called twice.

I'd said I'd do this as a separate commit. In practice it's one line inside the new `handleSubmit`, and splitting it would have meant deliberately re-introducing the bug in the first commit. Calling it out here instead.

## Also fixed while in there

Ids are now consistently scoped: `experience-title` / `experience-date` / `experience-content`. Previously only `title` was scoped — because it had already collided with the section form (#20). `date` and `content` were unscoped and would have collided the same way as soon as another panel used them.

## Tests — 10 covering the panel

Listing · distinguishing Edit button names · create · edit-prefill-and-update-by-id · both validation branches · the API failure path · delete-with-confirm in **both** directions · cancel · and that edit values don't leak into a subsequent create.

That last one is the kind of bug the old parallel-state design invited.

## Verification

```
Test Files  6 passed (6)
     Tests  27 passed (27)
```

`next build` exit 0 · `tsc --noEmit` 0 errors · `next lint --max-warnings=0` clean

Two things caught during this work, both worth noting as evidence the guardrails are doing their job:
- `tsc` caught 113 lines of stale JSX I'd left behind after removing the handlers — it referenced deleted state and would have been a runtime crash.
- The `no-unused-vars` rule from #21 caught an unused import in my own test file.

## Next

`ProjectManager` then `SectionManager`, same shape. Section is the awkward one — it carries the `content1/content2/content3` model and the duplicate PATCH implementations, so I'd expect that one to surface real questions rather than being a clean move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)