### PR TITLE
refactor: extract ProjectManager, fixing two order-handling bugs

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -6,14 +6,11 @@ import {
   createSection,
   updateSection,
   deleteSection,
-  getSectionHeaders,
-  createProject,
-  updateProject,
-  deleteProject,
-  getProjects
+  getSectionHeaders
 } from '../services'
 import { Header } from '@/lib/resume'
 import { ExperienceManager } from '@/components/admin/ExperienceManager'
+import { ProjectManager } from '@/components/admin/ProjectManager'
 import { CheckCircleIcon, XMarkIcon, XCircleIcon } from '@heroicons/react/24/outline'
 
 interface SuccessNotificationProps {
@@ -98,12 +95,6 @@ export default function AdminActions() {
   const [editingSectionContent2, setEditingSectionContent2] = useState('')
   const [editingSectionContent3, setEditingSectionContent3] = useState('')
 
-  const [projectName, setProjectName] = useState('')
-  const [projectDescription, setProjectDescription] = useState('')
-  const [projectLink, setProjectLink] = useState('')
-  const [projectLabel, setProjectLabel] = useState('')
-  const [projectOrder, setProjectOrder] = useState('')
-  const [projectLogo, setProjectLogo] = useState('')
 
   const [headers, setHeaders] = useState<Header[]>([])
   const [successMessage, setSuccessMessage] = useState('')
@@ -114,18 +105,9 @@ export default function AdminActions() {
   // Add new state variables for editing experiences
 
   // Add new state variables for editing projects
-  const [editingProjectId, setEditingProjectId] = useState('')
-  const [editingProjectName, setEditingProjectName] = useState('')
-  const [editingProjectDescription, setEditingProjectDescription] = useState('')
-  const [editingProjectLink, setEditingProjectLink] = useState('')
-  const [editingProjectLabel, setEditingProjectLabel] = useState('')
-  const [editingProjectOrder, setEditingProjectOrder] = useState('')
-  const [editingProjectLogo, setEditingProjectLogo] = useState('')
-  const [projects, setProjects] = useState<any[]>([])
 
   // Add mode state variables
 
-  const [showAddProjectForm, setShowAddProjectForm] = useState(false)
   const [showAddSectionForm, setShowAddSectionForm] = useState(false)
 
   const handleEditSection = (section: any) => {
@@ -184,34 +166,6 @@ export default function AdminActions() {
       })
   }
 
-  const handleProjectSubmit = async (event: React.FormEvent) => {
-    event.preventDefault()
-
-    if (!projectName || !projectDescription || !projectLink || !projectLabel) {
-      setErrorMessage('All fields are required')
-      return
-    }
-
-    let requestBody = {
-      name: projectName,
-      description: projectDescription,
-      link: projectLink,
-      label: projectLabel,
-      order: parseInt(projectOrder),
-      logo: projectLogo,
-    }
-
-    await createProject(requestBody)
-      .then(() => {
-        setSuccessMessage('Project added successfully')
-        clearAddProjectForm()
-      })
-      .catch((error) => {
-        setErrorMessage('Error adding project')
-        console.error('Error:', error)
-      })
-  }
-
   const handleEditingSectionSubmit = async (event: React.FormEvent) => {
     event.preventDefault()
 
@@ -265,76 +219,6 @@ export default function AdminActions() {
     setSectionContent3('')
   }
 
-  const clearAddProjectForm = () => {
-    setProjectName('')
-    setProjectDescription('')
-    setProjectLink('')
-    setProjectLabel('')
-    setProjectOrder('')
-    setProjectLogo('')
-  }
-
-  // Add new handlers for editing projects
-  const handleEditProject = (project: any) => {
-    setShowAddProjectForm(false)
-    clearAddProjectForm()
-    setEditingProjectId(project.id)
-    setEditingProjectName(project.name)
-    setEditingProjectDescription(project.description)
-    setEditingProjectLink(project.link)
-    setEditingProjectLabel(project.label)
-    setEditingProjectLogo(project.logo)
-  }
-
-  const handleEditingProjectSubmit = async (event: React.FormEvent) => {
-    event.preventDefault()
-
-    if (!editingProjectName || !editingProjectDescription || !editingProjectLink || !editingProjectLabel) {
-      setErrorMessage('All fields are required')
-      return
-    }
-
-    let requestBody = {
-      name: editingProjectName,
-      description: editingProjectDescription,
-      link: editingProjectLink,
-      label: editingProjectLabel,
-      order: parseInt(editingProjectOrder) || 0,
-      logo: editingProjectLogo,
-    }
-
-    await updateProject(editingProjectId, requestBody)
-      .then(() => {
-        setSuccessMessage('Project updated successfully')
-        clearEditingProject()
-        fetchProjects()
-      })
-      .catch((error) => {
-        setErrorMessage('Error updating project')
-        console.error('Error:', error)
-      })
-  }
-
-  const clearEditingProject = () => {
-    setEditingProjectId('')
-    setEditingProjectName('')
-    setEditingProjectDescription('')
-    setEditingProjectLink('')
-    setEditingProjectLabel('')
-    setEditingProjectOrder('')
-    setEditingProjectLogo('')
-  }
-
-  // Add fetch functions
-  const fetchProjects = async () => {
-    try {
-      const response = await getProjects()
-      setProjects(response)
-    } catch (error) {
-      console.error('Error fetching projects:', error)
-    }
-  }
-
   const fetchHeaders = async () => {
     try {
       const headersData = await getSectionHeaders()
@@ -346,10 +230,6 @@ export default function AdminActions() {
   }
 
   // Add useEffect to fetch data
-  useEffect(() => {
-    fetchProjects()
-  }, [])
-
   useEffect(() => {
     getSectionHeaders().then((response) => {
       setHeaders(response)
@@ -378,19 +258,6 @@ export default function AdminActions() {
     }
   }, [errorMessage])
 
-  const handleDeleteProject = async (id: string) => {
-    try {
-      await deleteProject(id)
-      await fetchProjects()
-      clearEditingProject()
-      setShowSuccess(true)
-      setSuccessMessage('Project deleted successfully!')
-    } catch (error) {
-      setShowError(true)
-      setErrorMessage('Failed to delete project.')
-    }
-  }
-
   const handleDeleteSection = async (id: string) => {
     try {
       await deleteSection(id)
@@ -412,143 +279,8 @@ export default function AdminActions() {
           onError={setErrorMessage}
         />
 
-        <div className="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40">
-          <h2 className="flex text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-            Project Management
-          </h2>
-          <div className="mt-6">
-            <div>
-              <div className="flex items-center justify-end px-3">
-                <button
-                  onClick={() => {
-                    setShowAddProjectForm(true)
-                    clearAddProjectForm()
-                  }}
-                  className="w-32 px-3 py-2 text-sm font-semibold text-zinc-900 dark:text-zinc-100 hover:underline bg-transparent border-none shadow-none"
-                >
-                  Create
-                </button>
-              </div>
-              {projects.map((project, index) => (
-                <div 
-                  key={project.id} 
-                  className={`flex items-center justify-between px-3 ${
-                    index % 2 === 0 ? 'bg-zinc-50 dark:bg-zinc-800/50' : ''
-                  }`}
-                >
-                  <span>{project.name}</span>
-                  <button
-                    onClick={() => handleEditProject(project)}
-                    aria-label={`Edit ${project.name}`}
-                    className="w-32 px-3 py-2 text-sm font-semibold text-zinc-900 dark:text-zinc-100 hover:underline bg-transparent border-none shadow-none"
-                  >
-                    Edit
-                  </button>
-                </div>
-              ))}
-            </div>
-            {(editingProjectId || showAddProjectForm) && (
-              <form onSubmit={showAddProjectForm ? handleProjectSubmit : handleEditingProjectSubmit} className="mt-6 space-y-4">
-                <div>
-                  <label htmlFor="name" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Name
-                  </label>
-                  <input
-                    type="text"
-                    id="name"
-                    value={showAddProjectForm ? projectName : editingProjectName}
-                    onChange={(e) => showAddProjectForm ? setProjectName(e.target.value) : setEditingProjectName(e.target.value)}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div>
-                  <label htmlFor="description" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Description
-                  </label>
-                  <textarea
-                    id="description"
-                    value={showAddProjectForm ? projectDescription : editingProjectDescription}
-                    onChange={(e) => showAddProjectForm ? setProjectDescription(e.target.value) : setEditingProjectDescription(e.target.value)}
-                    rows={4}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div>
-                  <label htmlFor="link" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Link
-                  </label>
-                  <input
-                    type="text"
-                    id="link"
-                    value={showAddProjectForm ? projectLink : editingProjectLink}
-                    onChange={(e) => showAddProjectForm ? setProjectLink(e.target.value) : setEditingProjectLink(e.target.value)}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div>
-                  <label htmlFor="label" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Label
-                  </label>
-                  <input
-                    type="text"
-                    id="label"
-                    value={showAddProjectForm ? projectLabel : editingProjectLabel}
-                    onChange={(e) => showAddProjectForm ? setProjectLabel(e.target.value) : setEditingProjectLabel(e.target.value)}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div>
-                  <label htmlFor="logo" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Logo URL
-                  </label>
-                  <input
-                    type="text"
-                    id="logo"
-                    value={showAddProjectForm ? projectLogo : editingProjectLogo}
-                    onChange={(e) => showAddProjectForm ? setProjectLogo(e.target.value) : setEditingProjectLogo(e.target.value)}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div className="flex justify-between space-x-4">
-                  {editingProjectId && (
-                    <button
-                      type="button"
-                      onClick={async () => {
-                        if (window.confirm('Are you sure you want to delete this project?')) {
-                          await handleDeleteProject(editingProjectId)
-                        }
-                      }}
-                      className="rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-700"
-                    >
-                      Delete
-                    </button>
-                  )}
-                  <div className="flex space-x-4">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setShowAddProjectForm(false)
-                        clearAddProjectForm()
-                        clearEditingProject()
-                      }}
-                      className="rounded-md bg-zinc-200 px-3 py-2 text-sm font-semibold text-zinc-900 shadow-sm hover:bg-zinc-300 dark:bg-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-600"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      type="submit"
-                      className="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
-                    >
-                      {showAddProjectForm ? 'Add Project' : 'Update Project'}
-                    </button>
-                  </div>
-                </div>
-              </form>
-            )}
-          </div>
-        </div>
+        <ProjectManager onSuccess={setSuccessMessage} onError={setErrorMessage} />
 
-        {/* Edit Section Section */}
         <div className="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40">
           <h2 className="flex text-sm font-semibold text-zinc-900 dark:text-zinc-100">
             Section Management

--- a/src/components/admin/ProjectManager.test.tsx
+++ b/src/components/admin/ProjectManager.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const svc = vi.hoisted(() => ({
+  getProjects: vi.fn(),
+  createProject: vi.fn(),
+  updateProject: vi.fn(),
+  deleteProject: vi.fn(),
+}))
+vi.mock('@/app/services', () => svc)
+
+import { ProjectManager } from './ProjectManager'
+
+const ROWS = [
+  { id: 'p1', name: 'Portfolio', description: 'This site', link: 'https://a', label: 'Github Link', order: 0, logo: '' },
+  { id: 'p2', name: 'Allegiance', description: 'Client work', link: 'https://b', label: 'Website Link', order: 1, logo: '' },
+]
+
+const onSuccess = vi.fn()
+const onError = vi.fn()
+
+function setup() {
+  render(<ProjectManager onSuccess={onSuccess} onError={onError} />)
+  return userEvent.setup()
+}
+
+describe('ProjectManager', () => {
+  beforeEach(() => {
+    onSuccess.mockReset(); onError.mockReset()
+    svc.getProjects.mockReset().mockResolvedValue(ROWS)
+    svc.createProject.mockReset().mockResolvedValue({})
+    svc.updateProject.mockReset().mockResolvedValue({})
+    svc.deleteProject.mockReset().mockResolvedValue({})
+  })
+
+  it('lists projects with distinguishable Edit buttons', async () => {
+    setup()
+    expect(await screen.findByRole('button', { name: 'Edit Portfolio' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit Allegiance' })).toBeInTheDocument()
+  })
+
+  it('prefills the order field when editing', async () => {
+    // Regression: handleEditProject never populated editingProjectOrder, and
+    // the form had no order input at all, so the value was unrecoverable.
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Edit Allegiance' }))
+    expect(screen.getByLabelText(/order/i)).toHaveValue(1)
+  })
+
+  it('preserves an existing order when editing other fields', async () => {
+    // Regression: `parseInt(editingProjectOrder) || 0` reset every edited
+    // project to order 0, silently destroying a deliberate ordering.
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Edit Allegiance' }))
+    const name = screen.getByLabelText(/name/i)
+    await user.clear(name)
+    await user.type(name, 'Allegiance HHC')
+    await user.click(screen.getByRole('button', { name: 'Update Project' }))
+
+    await waitFor(() =>
+      expect(svc.updateProject).toHaveBeenCalledWith(
+        'p2', expect.objectContaining({ name: 'Allegiance HHC', order: 1 }),
+      ),
+    )
+  })
+
+  it('keeps the current order when the box is cleared', async () => {
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Edit Allegiance' }))
+    await user.clear(screen.getByLabelText(/order/i))
+    await user.click(screen.getByRole('button', { name: 'Update Project' }))
+
+    await waitFor(() =>
+      expect(svc.updateProject).toHaveBeenCalledWith('p2', expect.objectContaining({ order: 1 })),
+    )
+  })
+
+  it('puts a new project at the end rather than sending null', async () => {
+    // Regression: parseInt('') is NaN, which JSON.stringify turns into null.
+    // That is how three of four live projects ended up with order: null.
+    const user = setup()
+    await screen.findByText('Portfolio')
+    await user.click(screen.getByRole('button', { name: 'Create' }))
+    for (const [label, value] of [[/name/i, 'New'], [/description/i, 'D'], [/link/i, 'https://c'], [/^label$/i, 'L']] as const) {
+      await user.type(screen.getByLabelText(label), value)
+    }
+    await user.click(screen.getByRole('button', { name: 'Add Project' }))
+
+    await waitFor(() =>
+      expect(svc.createProject).toHaveBeenCalledWith(expect.objectContaining({ name: 'New', order: 2 })),
+    )
+    expect(onSuccess).toHaveBeenCalledWith('Project added successfully')
+    expect(svc.getProjects).toHaveBeenCalledTimes(2) // list refreshes after add
+  })
+
+  it('honours an explicitly typed order', async () => {
+    const user = setup()
+    await screen.findByText('Portfolio')
+    await user.click(screen.getByRole('button', { name: 'Create' }))
+    for (const [label, value] of [[/name/i, 'N'], [/description/i, 'D'], [/link/i, 'https://c'], [/^label$/i, 'L']] as const) {
+      await user.type(screen.getByLabelText(label), value)
+    }
+    await user.type(screen.getByLabelText(/order/i), '7')
+    await user.click(screen.getByRole('button', { name: 'Add Project' }))
+
+    await waitFor(() =>
+      expect(svc.createProject).toHaveBeenCalledWith(expect.objectContaining({ order: 7 })),
+    )
+  })
+
+  it('rejects missing required fields without calling the API', async () => {
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Create' }))
+    await user.click(screen.getByRole('button', { name: 'Add Project' }))
+    expect(onError).toHaveBeenCalledWith('All fields are required')
+    expect(svc.createProject).not.toHaveBeenCalled()
+  })
+
+  it('reports API failures', async () => {
+    svc.updateProject.mockRejectedValue(new Error('nope'))
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Edit Portfolio' }))
+    await user.click(screen.getByRole('button', { name: 'Update Project' }))
+    await waitFor(() => expect(onError).toHaveBeenCalledWith('Error updating project'))
+  })
+
+  it('deletes only after confirmation', async () => {
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Edit Portfolio' }))
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+    expect(svc.deleteProject).not.toHaveBeenCalled()
+
+    confirm.mockReturnValue(true)
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+    await waitFor(() => expect(svc.deleteProject).toHaveBeenCalledWith('p1'))
+  })
+})

--- a/src/components/admin/ProjectManager.tsx
+++ b/src/components/admin/ProjectManager.tsx
@@ -1,0 +1,244 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+import {
+  createProject,
+  deleteProject,
+  getProjects,
+  updateProject,
+} from '@/app/services'
+
+export interface AdminProject {
+  id: string
+  name: string
+  description: string
+  link: string
+  label: string
+  order?: number | null
+  logo?: string | null
+}
+
+type Mode = { kind: 'closed' } | { kind: 'add' } | { kind: 'edit'; id: string }
+
+const EMPTY = { name: '', description: '', link: '', label: '', order: '', logo: '' }
+type Form = typeof EMPTY
+
+export function ProjectManager({
+  onSuccess,
+  onError,
+}: {
+  onSuccess: (message: string) => void
+  onError: (message: string) => void
+}) {
+  const [projects, setProjects] = useState<AdminProject[]>([])
+  const [mode, setMode] = useState<Mode>({ kind: 'closed' })
+  const [form, setForm] = useState<Form>(EMPTY)
+
+  const refresh = useCallback(async () => {
+    try {
+      setProjects(await getProjects())
+    } catch (error) {
+      console.error('Error fetching projects:', error)
+    }
+  }, [])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const close = () => {
+    setMode({ kind: 'closed' })
+    setForm(EMPTY)
+  }
+
+  /**
+   * `order` drives the sort on /projects. A blank box must never be written as
+   * NaN (which serialises to null) or silently coerced to 0 - both of those
+   * discard a deliberate ordering. Blank means "leave it where it is", and a
+   * brand new project goes on the end.
+   */
+  const resolveOrder = (): number => {
+    const typed = parseInt(form.order, 10)
+    if (!Number.isNaN(typed)) return typed
+    if (mode.kind === 'edit') {
+      const current = projects.find((p) => p.id === mode.id)?.order
+      if (typeof current === 'number') return current
+    }
+    const highest = projects.reduce(
+      (max, p) => (typeof p.order === 'number' && p.order > max ? p.order : max),
+      -1,
+    )
+    return highest + 1
+  }
+
+  const field = (name: keyof Form) => ({
+    id: `project-${name}`,
+    value: form[name],
+    onChange: (
+      e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    ) => setForm((f) => ({ ...f, [name]: e.target.value })),
+    className:
+      'mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm',
+  })
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (mode.kind === 'closed') return
+
+    if (!form.name || !form.description || !form.link || !form.label) {
+      onError('All fields are required')
+      return
+    }
+
+    const payload = {
+      name: form.name,
+      description: form.description,
+      link: form.link,
+      label: form.label,
+      order: resolveOrder(),
+      logo: form.logo,
+    }
+
+    const adding = mode.kind === 'add'
+    try {
+      if (adding) {
+        await createProject(payload)
+      } else {
+        await updateProject(mode.id, payload)
+      }
+      onSuccess(`Project ${adding ? 'added' : 'updated'} successfully`)
+      close()
+      await refresh()
+    } catch (error) {
+      onError(`Error ${adding ? 'adding' : 'updating'} project`)
+      console.error('Error:', error)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (mode.kind !== 'edit') return
+    if (!window.confirm('Are you sure you want to delete this project?')) return
+
+    try {
+      await deleteProject(mode.id)
+      close()
+      await refresh()
+      onSuccess('Project deleted successfully!')
+    } catch (error) {
+      onError('Failed to delete project.')
+    }
+  }
+
+  const rowButton =
+    'w-32 px-3 py-2 text-sm font-semibold text-zinc-900 dark:text-zinc-100 hover:underline bg-transparent border-none shadow-none'
+  const labelClass =
+    'block text-sm font-medium text-zinc-900 dark:text-zinc-100'
+
+  return (
+    <div className="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40">
+      <h2 className="flex text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+        Project Management
+      </h2>
+      <div className="mt-6">
+        <div>
+          <div className="flex items-center justify-end px-3">
+            <button
+              onClick={() => {
+                setForm(EMPTY)
+                setMode({ kind: 'add' })
+              }}
+              className={rowButton}
+            >
+              Create
+            </button>
+          </div>
+          {projects.map((project, index) => (
+            <div
+              key={project.id}
+              className={`flex items-center justify-between px-3 ${
+                index % 2 === 0 ? 'bg-zinc-50 dark:bg-zinc-800/50' : ''
+              }`}
+            >
+              <span>{project.name}</span>
+              <button
+                onClick={() => {
+                  setForm({
+                    name: project.name,
+                    description: project.description,
+                    link: project.link,
+                    label: project.label,
+                    order: typeof project.order === 'number' ? String(project.order) : '',
+                    logo: project.logo ?? '',
+                  })
+                  setMode({ kind: 'edit', id: project.id })
+                }}
+                aria-label={`Edit ${project.name}`}
+                className={rowButton}
+              >
+                Edit
+              </button>
+            </div>
+          ))}
+        </div>
+
+        {mode.kind !== 'closed' && (
+          <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+            <div>
+              <label htmlFor="project-name" className={labelClass}>Name</label>
+              <input type="text" {...field('name')} />
+            </div>
+            <div>
+              <label htmlFor="project-description" className={labelClass}>Description</label>
+              <textarea rows={4} {...field('description')} />
+            </div>
+            <div>
+              <label htmlFor="project-link" className={labelClass}>Link</label>
+              <input type="text" {...field('link')} />
+            </div>
+            <div>
+              <label htmlFor="project-label" className={labelClass}>Label</label>
+              <input type="text" {...field('label')} />
+            </div>
+            <div>
+              <label htmlFor="project-order" className={labelClass}>
+                Order (lowest first; blank keeps the current position)
+              </label>
+              <input type="number" {...field('order')} />
+            </div>
+            <div>
+              <label htmlFor="project-logo" className={labelClass}>Logo</label>
+              <input type="text" {...field('logo')} />
+            </div>
+            <div className="flex justify-between space-x-4">
+              {mode.kind === 'edit' && (
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  className="rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-700"
+                >
+                  Delete
+                </button>
+              )}
+              <div className="flex space-x-4">
+                <button
+                  type="button"
+                  onClick={close}
+                  className="rounded-md bg-zinc-200 px-3 py-2 text-sm font-semibold text-zinc-900 shadow-sm hover:bg-zinc-300 dark:bg-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-600"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+                >
+                  {mode.kind === 'add' ? 'Add Project' : 'Update Project'}
+                </button>
+              </div>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
> Stacked on #23. Base is `refactor/extract-experience-manager` so the diff stays reviewable; GitHub retargets automatically as the stack merges.

Second panel extraction.

```
admin/page.tsx   719 → 451 lines,   37 → 22 useState
```

Same shape as #23 — one `form` object plus a discriminated `closed | add | edit` mode replaces two parallel state sets and **fifteen** individual `useState` declarations.

## Two real bugs, both around `order`

While extracting I found the project form **never rendered an order input at all**. It renders name, description, link, label and logo — but `projectOrder` and `editingProjectOrder` were declared, read on submit, and never written by anything.

**1. Creating a project wrote `order: null`.**
`parseInt('')` is `NaN`, and `JSON.stringify` turns `NaN` into `null`. This is exactly how three of your four live projects ended up with `order: null`.

**2. Editing a project reset its order to `0`.**
`handleEditProject` populated id, name, description, link, label and logo — but not order. Combined with `parseInt(editingProjectOrder) || 0` on submit, **opening any project and saving it silently discarded its position.** Editing two projects would have collapsed both to `0`.

That second one would have quietly undone the ordering I wrote to the database in #19, the first time you touched a project in `/admin`.

The component now renders an Order field, prefills it when editing, and treats a blank box as *"leave it where it is"*:

| Situation | Result |
|---|---|
| Number typed | that number |
| Blank, editing | the project's current order |
| Blank, creating | highest existing + 1 |

Also fixed, consistent with #23: the create path never re-fetched, so a new project didn't appear until a page reload.

## A correction to something I said earlier

PR #19 claimed *"the admin UI collects an `order` for every project."* **That was wrong.** The state existed but no input ever set it — which is the actual root cause of the null orders that PR worked around by writing values straight to the database. The database fix was still right; the explanation wasn't.

## Tests — 9

Listing · order prefill on edit · **order preserved when editing other fields** · blank box keeping current order · new projects appended rather than nulled · explicit order honoured · validation · API failure · delete-with-confirm both ways.

The three bolded-in-spirit ones are direct regression tests for the bugs above.

## Verification

```
Test Files  7 passed (7)
     Tests  36 passed (36)
```

`next build` exit 0 · `tsc --noEmit` 0 errors · `next lint` clean

## Next

`SectionManager` — the awkward one. It carries the `content1/content2/content3` model, two competing PATCH implementations on the server, and the section-title id that collided in #20. I expect that one to surface design questions rather than being a mechanical move, so I'll flag anything that needs your call rather than deciding it myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)