### PR TITLE
fix: update the stale h1 and default title to match the rewritten copy

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,7 +9,7 @@ import '@/styles/tailwind.css'
 export const metadata: Metadata = {
   title: {
     template: '%s - DeRon Sutton',
-    default: 'DeRon Sutton - Full Stack Software Developer',
+    default: 'DeRon Sutton - Full-Stack Software Engineer',
   },
   description:
     'I’m DeRon, a software engineer based in St. Louis. At Omni Federal I build full-stack applications for federal geospatial workflows; before that I spent three years at AT&T on internal tools used across the company.',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -175,7 +175,7 @@ export default async function Home() {
       <Container className="mt-9">
         <div className="max-w-2xl">
           <h1 className="text-4xl font-bold tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100">
-            Full Stack Software Developer
+            Full-Stack Software Engineer
           </h1>
           <p className="mt-6 text-base text-zinc-600 dark:text-zinc-400">
             I&apos;m DeRon, a software engineer based in St. Louis. At Omni


### PR DESCRIPTION
My miss in #17. I rewrote the home page paragraph and the meta description, but missed the heading directly above it and the default title two lines up — so the page contradicted itself:

```html
<h1>Full Stack Software Developer</h1>
<p>I'm DeRon, a software engineer based in St. Louis. At Omni Federal…</p>
```

One job title in the heading, a different one in the sentence directly underneath. Nothing was functionally broken, but it reads as wrong — which is fair.

| | Before | After |
|---|---|---|
| `<h1>` | Full Stack Software Developer | **Full-Stack Software Engineer** |
| `title.default` | DeRon Sutton - Full Stack Software Developer | **DeRon Sutton - Full-Stack Software Engineer** |

"Full-Stack Software Engineer" matches both your résumé summary and the paragraph's own wording.

The default title only shows on the home page — `/resume`, `/experience`, `/projects`, `/login` and `/admin` all set their own and were already correct.

## Verification

`next build` exit 0 · `tsc --noEmit` 0 errors · `next lint` clean · 17/17 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)