### PR TITLE
refactor: split the admin page into three panel components (replaces #23, #24, #25)

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -10,13 +10,10 @@ import {
   createProject,
   updateProject,
   deleteProject,
-  getProjects,
-  createExperience,
-  updateExperience,
-  deleteExperience,
-  getExperiences
+  getProjects
 } from '../services'
 import { Header } from '@/lib/resume'
+import { ExperienceManager } from '@/components/admin/ExperienceManager'
 import { CheckCircleIcon, XMarkIcon, XCircleIcon } from '@heroicons/react/24/outline'
 
 interface SuccessNotificationProps {
@@ -84,9 +81,6 @@ function ErrorNotification({ message, onClose }: ErrorNotificationProps) {
 }
 
 export default function AdminActions() {
-  const [experienceTitle, setExperienceTitle] = useState('')
-  const [experienceDate, setExperienceDate] = useState('')
-  const [experienceContent, setExperienceContent] = useState('')
   const [sectionTitle, setSectionTitle] = useState('')
   const [sectionOrder, setSectionOrder] = useState('')
   const [sectionHeader, setSectionHeader] = useState('')
@@ -118,11 +112,6 @@ export default function AdminActions() {
   const [showError, setShowError] = useState(false)
 
   // Add new state variables for editing experiences
-  const [editingExperienceId, setEditingExperienceId] = useState('')
-  const [editingExperienceTitle, setEditingExperienceTitle] = useState('')
-  const [editingExperienceDate, setEditingExperienceDate] = useState('')
-  const [editingExperienceContent, setEditingExperienceContent] = useState('')
-  const [experiences, setExperiences] = useState<any[]>([])
 
   // Add new state variables for editing projects
   const [editingProjectId, setEditingProjectId] = useState('')
@@ -136,7 +125,6 @@ export default function AdminActions() {
 
   // Add mode state variables
 
-  const [showAddExperienceForm, setShowAddExperienceForm] = useState(false)
   const [showAddProjectForm, setShowAddProjectForm] = useState(false)
   const [showAddSectionForm, setShowAddSectionForm] = useState(false)
 
@@ -157,37 +145,6 @@ export default function AdminActions() {
       })
       .catch((error) => {
         console.error('Error fetching section:', error)
-      })
-  }
-
-  const handleExperienceSubmit = async (event: React.FormEvent) => {
-    event.preventDefault()
-
-    if (!experienceTitle || !experienceDate || !experienceContent) {
-      setErrorMessage('All fields are required')
-      return
-    }
-
-    const dateRegex = /^\d{4}-\d{2}-\d{2}$/
-    if (!dateRegex.test(experienceDate)) {
-      setErrorMessage('Invalid date format')
-      return
-    }
-
-    let requestBody = {
-      title: experienceTitle,
-      date: experienceDate,
-      content: experienceContent,
-    }
-
-    await createExperience(requestBody)
-      .then(() => {
-        setSuccessMessage('Experience added successfully')
-        clearAddExperienceForm()
-      })
-      .catch((error) => {
-        setErrorMessage('Error adding experience')
-        console.error('Error:', error)
       })
   }
 
@@ -308,12 +265,6 @@ export default function AdminActions() {
     setSectionContent3('')
   }
 
-  const clearAddExperienceForm = () => {
-    setExperienceTitle('')
-    setExperienceDate('')
-    setExperienceContent('')
-  }
-
   const clearAddProjectForm = () => {
     setProjectName('')
     setProjectDescription('')
@@ -321,55 +272,6 @@ export default function AdminActions() {
     setProjectLabel('')
     setProjectOrder('')
     setProjectLogo('')
-  }
-
-  // Add new handlers for editing experiences
-  const handleEditExperience = (experience: any) => {
-    setShowAddExperienceForm(false)
-    clearAddExperienceForm()
-    setEditingExperienceId(experience.id)
-    setEditingExperienceTitle(experience.title)
-    setEditingExperienceDate(experience.date)
-    setEditingExperienceContent(experience.content)
-  }
-
-  const handleEditingExperienceSubmit = async (event: React.FormEvent) => {
-    event.preventDefault()
-
-    if (!editingExperienceTitle || !editingExperienceDate || !editingExperienceContent) {
-      setErrorMessage('All fields are required')
-      return
-    }
-
-    const dateRegex = /^\d{4}-\d{2}-\d{2}$/
-    if (!dateRegex.test(editingExperienceDate)) {
-      setErrorMessage('Invalid date format')
-      return
-    }
-
-    let requestBody = {
-      title: editingExperienceTitle,
-      date: editingExperienceDate,
-      content: editingExperienceContent,
-    }
-
-    await updateExperience(editingExperienceId, requestBody)
-      .then(() => {
-        setSuccessMessage('Experience updated successfully')
-        clearEditingExperience()
-        fetchExperiences()
-      })
-      .catch((error) => {
-        setErrorMessage('Error updating experience')
-        console.error('Error:', error)
-      })
-  }
-
-  const clearEditingExperience = () => {
-    setEditingExperienceId('')
-    setEditingExperienceTitle('')
-    setEditingExperienceDate('')
-    setEditingExperienceContent('')
   }
 
   // Add new handlers for editing projects
@@ -424,15 +326,6 @@ export default function AdminActions() {
   }
 
   // Add fetch functions
-  const fetchExperiences = async () => {
-    try {
-      const response = await getExperiences()
-      setExperiences(response)
-    } catch (error) {
-      console.error('Error fetching experiences:', error)
-    }
-  }
-
   const fetchProjects = async () => {
     try {
       const response = await getProjects()
@@ -454,7 +347,6 @@ export default function AdminActions() {
 
   // Add useEffect to fetch data
   useEffect(() => {
-    fetchExperiences()
     fetchProjects()
   }, [])
 
@@ -486,19 +378,6 @@ export default function AdminActions() {
     }
   }, [errorMessage])
 
-  const handleDeleteExperience = async (id: string) => {
-    try {
-      await deleteExperience(id)
-      await fetchExperiences()
-      clearEditingExperience()
-      setShowSuccess(true)
-      setSuccessMessage('Experience deleted successfully!')
-    } catch (error) {
-      setShowError(true)
-      setErrorMessage('Failed to delete experience.')
-    }
-  }
-
   const handleDeleteProject = async (id: string) => {
     try {
       await deleteProject(id)
@@ -528,120 +407,11 @@ export default function AdminActions() {
   return (
     <SimpleLayout title="Admin" intro="">
       <div className="space-y-8">
-        {/* Edit Experience Section */}
-        <div className="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40">
-          <h2 className="flex text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-            Experience Management
-          </h2>
-          <div className="mt-6">
-            <div>
-              <div className="flex items-center justify-end px-3">
-                <button
-                  onClick={() => {
-                    setShowAddExperienceForm(true)
-                    clearAddExperienceForm()
-                  }}
-                  className="w-32 px-3 py-2 text-sm font-semibold text-zinc-900 dark:text-zinc-100 hover:underline bg-transparent border-none shadow-none"
-                >
-                  Create
-                </button>
-              </div>
-              {experiences.map((experience, index) => (
-                <div 
-                  key={experience.id} 
-                  className={`flex items-center justify-between px-3 ${
-                    index % 2 === 0 ? 'bg-zinc-50 dark:bg-zinc-800/50' : ''
-                  }`}
-                >
-                  <span>{experience.title}</span>
-                  <button
-                    onClick={() => handleEditExperience(experience)}
-                    aria-label={`Edit ${experience.title}`}
-                    className="w-32 px-3 py-2 text-sm font-semibold text-zinc-900 dark:text-zinc-100 hover:underline bg-transparent border-none shadow-none"
-                  >
-                    Edit
-                  </button>
-                </div>
-              ))}
-            </div>
-            {(editingExperienceId || showAddExperienceForm) && (
-              <form onSubmit={showAddExperienceForm ? handleExperienceSubmit : handleEditingExperienceSubmit} className="mt-6 space-y-4">
-                <div>
-                  <label htmlFor="experience-title" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Title
-                  </label>
-                  <input
-                    type="text"
-                    id="experience-title"
-                    value={showAddExperienceForm ? experienceTitle : editingExperienceTitle}
-                    onChange={(e) => showAddExperienceForm ? setExperienceTitle(e.target.value) : setEditingExperienceTitle(e.target.value)}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div>
-                  <label htmlFor="date" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Date (YYYY-MM-DD)
-                  </label>
-                  <input
-                    type="text"
-                    id="date"
-                    value={showAddExperienceForm ? experienceDate : editingExperienceDate}
-                    onChange={(e) => showAddExperienceForm ? setExperienceDate(e.target.value) : setEditingExperienceDate(e.target.value)}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div>
-                  <label htmlFor="content" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Content
-                  </label>
-                  <textarea
-                    id="content"
-                    value={showAddExperienceForm ? experienceContent : editingExperienceContent}
-                    onChange={(e) => showAddExperienceForm ? setExperienceContent(e.target.value) : setEditingExperienceContent(e.target.value)}
-                    rows={4}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div className="flex justify-between space-x-4">
-                  {editingExperienceId && (
-                    <button
-                      type="button"
-                      onClick={async () => {
-                        if (window.confirm('Are you sure you want to delete this experience?')) {
-                          await handleDeleteExperience(editingExperienceId)
-                        }
-                      }}
-                      className="rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-700"
-                    >
-                      Delete
-                    </button>
-                  )}
-                  <div className="flex space-x-4">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setShowAddExperienceForm(false)
-                        clearAddExperienceForm()
-                        clearEditingExperience()
-                      }}
-                      className="rounded-md bg-zinc-200 px-3 py-2 text-sm font-semibold text-zinc-900 shadow-sm hover:bg-zinc-300 dark:bg-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-600"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      type="submit"
-                      className="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
-                    >
-                      {showAddExperienceForm ? 'Add Experience' : 'Update Experience'}
-                    </button>
-                  </div>
-                </div>
-              </form>
-            )}
-          </div>
-        </div>
+        <ExperienceManager
+          onSuccess={setSuccessMessage}
+          onError={setErrorMessage}
+        />
 
-        {/* Edit Project Section */}
         <div className="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40">
           <h2 className="flex text-sm font-semibold text-zinc-900 dark:text-zinc-100">
             Project Management

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,15 +2,9 @@
 
 import { SimpleLayout } from '@/components/SimpleLayout'
 import { useState, useEffect } from 'react'
-import {
-  createSection,
-  updateSection,
-  deleteSection,
-  getSectionHeaders
-} from '../services'
-import { Header } from '@/lib/resume'
 import { ExperienceManager } from '@/components/admin/ExperienceManager'
 import { ProjectManager } from '@/components/admin/ProjectManager'
+import { SectionManager } from '@/components/admin/SectionManager'
 import { CheckCircleIcon, XMarkIcon, XCircleIcon } from '@heroicons/react/24/outline'
 
 interface SuccessNotificationProps {
@@ -78,163 +72,10 @@ function ErrorNotification({ message, onClose }: ErrorNotificationProps) {
 }
 
 export default function AdminActions() {
-  const [sectionTitle, setSectionTitle] = useState('')
-  const [sectionOrder, setSectionOrder] = useState('')
-  const [sectionHeader, setSectionHeader] = useState('')
-  const [sectionSubHeader, setSectionSubHeader] = useState('')
-  const [sectionContent1, setSectionContent1] = useState('')
-  const [sectionContent2, setSectionContent2] = useState('')
-  const [sectionContent3, setSectionContent3] = useState('')
-
-  const [editingSectionId, setEditingSectionId] = useState('')
-  const [editingSectionTitle, setEditingSectionTitle] = useState('')
-  const [editingSectionOrder, setEditingSectionOrder] = useState('')
-  const [editingSectionHeader, setEditingSectionHeader] = useState('')
-  const [editingSectionSubHeader, setEditingSectionSubHeader] = useState('')
-  const [editingSectionContent1, setEditingSectionContent1] = useState('')
-  const [editingSectionContent2, setEditingSectionContent2] = useState('')
-  const [editingSectionContent3, setEditingSectionContent3] = useState('')
-
-
-  const [headers, setHeaders] = useState<Header[]>([])
   const [successMessage, setSuccessMessage] = useState('')
   const [errorMessage, setErrorMessage] = useState('')
   const [showSuccess, setShowSuccess] = useState(false)
   const [showError, setShowError] = useState(false)
-
-  // Add new state variables for editing experiences
-
-  // Add new state variables for editing projects
-
-  // Add mode state variables
-
-  const [showAddSectionForm, setShowAddSectionForm] = useState(false)
-
-  const handleEditSection = (section: any) => {
-    setShowAddSectionForm(false)
-    clearAddSectionForm()
-    fetch(`/api/sections/${section.id}`)
-      .then((res) => res.json())
-      .then((data) => {
-        setEditingSectionId(data.id)
-        setEditingSectionTitle(data.title || '')
-        setEditingSectionOrder(data.order || '')
-        setEditingSectionHeader(data.header || '')
-        setEditingSectionSubHeader(data.subHeader || '')
-        setEditingSectionContent1(data.contents?.[0]?.content || '')
-        setEditingSectionContent2(data.contents?.[1]?.content || '')
-        setEditingSectionContent3(data.contents?.[2]?.content || '')
-      })
-      .catch((error) => {
-        console.error('Error fetching section:', error)
-      })
-  }
-
-  const handleSectionSubmit = async (event: React.FormEvent) => {
-    event.preventDefault()
-
-    if (!sectionTitle || !sectionHeader) {
-      setErrorMessage('Title and Header are required')
-      return
-    }
-
-    let requestBody = {
-      title: sectionTitle,
-      order: parseInt(sectionOrder),
-      header: sectionHeader,
-      subHeader: sectionSubHeader,
-      contents: {
-        records: [
-          { content: sectionContent1 },
-          { content: sectionContent2 },
-          { content: sectionContent3 },
-        ],
-      },
-    }
-
-    await createSection(requestBody)
-      .then(() => {
-        setSuccessMessage('Section added successfully')
-        clearAddSectionForm()
-        getSectionHeaders().then((response) => {
-          setHeaders(response)
-        })
-      })
-      .catch((error) => {
-        setErrorMessage('Error adding section')
-        console.error('Error:', error)
-      })
-  }
-
-  const handleEditingSectionSubmit = async (event: React.FormEvent) => {
-    event.preventDefault()
-
-    if (!editingSectionTitle || !editingSectionHeader) {
-      setErrorMessage('Title and Header are required')
-      return
-    }
-
-    let requestBody = {
-      title: editingSectionTitle,
-      order: parseInt(editingSectionOrder) || 0,
-      header: editingSectionHeader,
-      subHeader: editingSectionSubHeader,
-      content1: editingSectionContent1,
-      content2: editingSectionContent2,
-      content3: editingSectionContent3
-    }
-
-    await updateSection(editingSectionId, requestBody)
-      .then(() => {
-        setSuccessMessage('Section updated successfully')
-        clearEditingSection()
-        getSectionHeaders().then((response) => {
-          setHeaders(response)
-        })
-      })
-      .catch((error) => {
-        setErrorMessage('Error updating section')
-        console.error('Error:', error)
-      })
-  }
-
-  const clearEditingSection = () => {
-    setEditingSectionId('')
-    setEditingSectionTitle('')
-    setEditingSectionOrder('')
-    setEditingSectionHeader('')
-    setEditingSectionSubHeader('')
-    setEditingSectionContent1('')
-    setEditingSectionContent2('')
-    setEditingSectionContent3('')
-  }
-
-  const clearAddSectionForm = () => {
-    setSectionTitle('')
-    setSectionOrder('')
-    setSectionHeader('')
-    setSectionSubHeader('')
-    setSectionContent1('')
-    setSectionContent2('')
-    setSectionContent3('')
-  }
-
-  const fetchHeaders = async () => {
-    try {
-      const headersData = await getSectionHeaders()
-      setHeaders(headersData)
-    } catch (error) {
-      setShowError(true)
-      setErrorMessage('Failed to fetch section headers.')
-    }
-  }
-
-  // Add useEffect to fetch data
-  useEffect(() => {
-    getSectionHeaders().then((response) => {
-      setHeaders(response)
-    })
-  }, [])
 
   useEffect(() => {
     if (successMessage) {
@@ -258,19 +99,6 @@ export default function AdminActions() {
     }
   }, [errorMessage])
 
-  const handleDeleteSection = async (id: string) => {
-    try {
-      await deleteSection(id)
-      await fetchHeaders()
-      clearEditingSection()
-      setShowSuccess(true)
-      setSuccessMessage('Section deleted successfully!')
-    } catch (error) {
-      setShowError(true)
-      setErrorMessage('Failed to delete section.')
-    }
-  }
-
   return (
     <SimpleLayout title="Admin" intro="">
       <div className="space-y-8">
@@ -281,170 +109,21 @@ export default function AdminActions() {
 
         <ProjectManager onSuccess={setSuccessMessage} onError={setErrorMessage} />
 
-        <div className="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40">
-          <h2 className="flex text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-            Section Management
-          </h2>
-          <div className="mt-6">
-            <div>
-              <div className="flex items-center px-3">
-                <span className="flex-1"></span>
-                <button
-                  onClick={() => {
-                    setShowAddSectionForm(true)
-                    clearAddSectionForm()
-                  }}
-                  className="w-32 px-3 py-2 text-sm font-semibold text-zinc-900 dark:text-zinc-100 hover:underline bg-transparent border-none shadow-none"
-                >
-                  Create
-                </button>
-              </div>
-              {headers && headers.map((header: any, index: number) => (
-                <div
-                  key={header.id}
-                  className={`flex items-center px-3 ${
-                    (index + 1) % 2 === 0 ? 'bg-zinc-50 dark:bg-zinc-800/50' : ''
-                  }`}
-                >
-                  <span className="flex-1">{header.header}</span>
-                  <button
-                    onClick={() => handleEditSection(header)}
-                    aria-label={`Edit ${header.header}`}
-                    className="w-32 px-3 py-2 text-sm font-semibold text-zinc-900 dark:text-zinc-100 hover:underline bg-transparent border-none shadow-none"
-                  >
-                    Edit
-                  </button>
-                </div>
-              ))}
-            </div>
-            {(editingSectionId || showAddSectionForm) && (
-              <form onSubmit={showAddSectionForm ? handleSectionSubmit : handleEditingSectionSubmit} className="mt-6 space-y-4">
-                <div>
-                  <label htmlFor="section-title" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Title
-                  </label>
-                  <input
-                    type="text"
-                    id="section-title"
-                    value={showAddSectionForm ? sectionTitle : editingSectionTitle}
-                    onChange={(e) => showAddSectionForm ? setSectionTitle(e.target.value) : setEditingSectionTitle(e.target.value)}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div>
-                  <label htmlFor="order" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Order
-                  </label>
-                  <input
-                    type="number"
-                    id="order"
-                    value={showAddSectionForm ? sectionOrder : editingSectionOrder}
-                    onChange={(e) => showAddSectionForm ? setSectionOrder(e.target.value) : setEditingSectionOrder(e.target.value)}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div>
-                  <label htmlFor="header" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Header
-                  </label>
-                  <input
-                    type="text"
-                    id="header"
-                    value={showAddSectionForm ? sectionHeader : editingSectionHeader}
-                    onChange={(e) => showAddSectionForm ? setSectionHeader(e.target.value) : setEditingSectionHeader(e.target.value)}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div>
-                  <label htmlFor="subHeader" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Sub Header
-                  </label>
-                  <input
-                    type="text"
-                    id="subHeader"
-                    value={showAddSectionForm ? sectionSubHeader : editingSectionSubHeader}
-                    onChange={(e) => showAddSectionForm ? setSectionSubHeader(e.target.value) : setEditingSectionSubHeader(e.target.value)}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div>
-                  <label htmlFor="content1" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Content 1
-                  </label>
-                  <textarea
-                    id="content1"
-                    value={showAddSectionForm ? sectionContent1 : editingSectionContent1}
-                    onChange={(e) => showAddSectionForm ? setSectionContent1(e.target.value) : setEditingSectionContent1(e.target.value)}
-                    rows={4}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div>
-                  <label htmlFor="content2" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Content 2
-                  </label>
-                  <textarea
-                    id="content2"
-                    value={showAddSectionForm ? sectionContent2 : editingSectionContent2}
-                    onChange={(e) => showAddSectionForm ? setSectionContent2(e.target.value) : setEditingSectionContent2(e.target.value)}
-                    rows={4}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div>
-                  <label htmlFor="content3" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Content 3
-                  </label>
-                  <textarea
-                    id="content3"
-                    value={showAddSectionForm ? sectionContent3 : editingSectionContent3}
-                    onChange={(e) => showAddSectionForm ? setSectionContent3(e.target.value) : setEditingSectionContent3(e.target.value)}
-                    rows={4}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div className="flex justify-between space-x-4">
-                  {editingSectionId && (
-                    <button
-                      type="button"
-                      onClick={async () => {
-                        if (window.confirm('Are you sure you want to delete this section?')) {
-                          await handleDeleteSection(editingSectionId)
-                        }
-                      }}
-                      className="rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-700"
-                    >
-                      Delete
-                    </button>
-                  )}
-                  <div className="flex space-x-4">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setShowAddSectionForm(false)
-                        clearAddSectionForm()
-                        clearEditingSection()
-                      }}
-                      className="rounded-md bg-zinc-200 px-3 py-2 text-sm font-semibold text-zinc-900 shadow-sm hover:bg-zinc-300 dark:bg-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-600"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      type="submit"
-                      className="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
-                    >
-                      {showAddSectionForm ? 'Add Section' : 'Update Section'}
-                    </button>
-                  </div>
-                </div>
-              </form>
-            )}
-          </div>
-        </div>
+        <SectionManager onSuccess={setSuccessMessage} onError={setErrorMessage} />
 
         {/* Success and Error Notifications */}
-        {showSuccess && <SuccessNotification message={successMessage} onClose={() => setShowSuccess(false)} />}
-        {showError && <ErrorNotification message={errorMessage} onClose={() => setShowError(false)} />}
+        {showSuccess && (
+          <SuccessNotification
+            message={successMessage}
+            onClose={() => setShowSuccess(false)}
+          />
+        )}
+        {showError && (
+          <ErrorNotification
+            message={errorMessage}
+            onClose={() => setShowError(false)}
+          />
+        )}
       </div>
     </SimpleLayout>
   )

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -6,14 +6,11 @@ import {
   createSection,
   updateSection,
   deleteSection,
-  getSectionHeaders,
-  createProject,
-  updateProject,
-  deleteProject,
-  getProjects
+  getSectionHeaders
 } from '../services'
 import { Header } from '@/lib/resume'
 import { ExperienceManager } from '@/components/admin/ExperienceManager'
+import { ProjectManager } from '@/components/admin/ProjectManager'
 import { CheckCircleIcon, XMarkIcon, XCircleIcon } from '@heroicons/react/24/outline'
 
 interface SuccessNotificationProps {
@@ -98,12 +95,6 @@ export default function AdminActions() {
   const [editingSectionContent2, setEditingSectionContent2] = useState('')
   const [editingSectionContent3, setEditingSectionContent3] = useState('')
 
-  const [projectName, setProjectName] = useState('')
-  const [projectDescription, setProjectDescription] = useState('')
-  const [projectLink, setProjectLink] = useState('')
-  const [projectLabel, setProjectLabel] = useState('')
-  const [projectOrder, setProjectOrder] = useState('')
-  const [projectLogo, setProjectLogo] = useState('')
 
   const [headers, setHeaders] = useState<Header[]>([])
   const [successMessage, setSuccessMessage] = useState('')
@@ -114,18 +105,9 @@ export default function AdminActions() {
   // Add new state variables for editing experiences
 
   // Add new state variables for editing projects
-  const [editingProjectId, setEditingProjectId] = useState('')
-  const [editingProjectName, setEditingProjectName] = useState('')
-  const [editingProjectDescription, setEditingProjectDescription] = useState('')
-  const [editingProjectLink, setEditingProjectLink] = useState('')
-  const [editingProjectLabel, setEditingProjectLabel] = useState('')
-  const [editingProjectOrder, setEditingProjectOrder] = useState('')
-  const [editingProjectLogo, setEditingProjectLogo] = useState('')
-  const [projects, setProjects] = useState<any[]>([])
 
   // Add mode state variables
 
-  const [showAddProjectForm, setShowAddProjectForm] = useState(false)
   const [showAddSectionForm, setShowAddSectionForm] = useState(false)
 
   const handleEditSection = (section: any) => {
@@ -184,34 +166,6 @@ export default function AdminActions() {
       })
   }
 
-  const handleProjectSubmit = async (event: React.FormEvent) => {
-    event.preventDefault()
-
-    if (!projectName || !projectDescription || !projectLink || !projectLabel) {
-      setErrorMessage('All fields are required')
-      return
-    }
-
-    let requestBody = {
-      name: projectName,
-      description: projectDescription,
-      link: projectLink,
-      label: projectLabel,
-      order: parseInt(projectOrder),
-      logo: projectLogo,
-    }
-
-    await createProject(requestBody)
-      .then(() => {
-        setSuccessMessage('Project added successfully')
-        clearAddProjectForm()
-      })
-      .catch((error) => {
-        setErrorMessage('Error adding project')
-        console.error('Error:', error)
-      })
-  }
-
   const handleEditingSectionSubmit = async (event: React.FormEvent) => {
     event.preventDefault()
 
@@ -265,76 +219,6 @@ export default function AdminActions() {
     setSectionContent3('')
   }
 
-  const clearAddProjectForm = () => {
-    setProjectName('')
-    setProjectDescription('')
-    setProjectLink('')
-    setProjectLabel('')
-    setProjectOrder('')
-    setProjectLogo('')
-  }
-
-  // Add new handlers for editing projects
-  const handleEditProject = (project: any) => {
-    setShowAddProjectForm(false)
-    clearAddProjectForm()
-    setEditingProjectId(project.id)
-    setEditingProjectName(project.name)
-    setEditingProjectDescription(project.description)
-    setEditingProjectLink(project.link)
-    setEditingProjectLabel(project.label)
-    setEditingProjectLogo(project.logo)
-  }
-
-  const handleEditingProjectSubmit = async (event: React.FormEvent) => {
-    event.preventDefault()
-
-    if (!editingProjectName || !editingProjectDescription || !editingProjectLink || !editingProjectLabel) {
-      setErrorMessage('All fields are required')
-      return
-    }
-
-    let requestBody = {
-      name: editingProjectName,
-      description: editingProjectDescription,
-      link: editingProjectLink,
-      label: editingProjectLabel,
-      order: parseInt(editingProjectOrder) || 0,
-      logo: editingProjectLogo,
-    }
-
-    await updateProject(editingProjectId, requestBody)
-      .then(() => {
-        setSuccessMessage('Project updated successfully')
-        clearEditingProject()
-        fetchProjects()
-      })
-      .catch((error) => {
-        setErrorMessage('Error updating project')
-        console.error('Error:', error)
-      })
-  }
-
-  const clearEditingProject = () => {
-    setEditingProjectId('')
-    setEditingProjectName('')
-    setEditingProjectDescription('')
-    setEditingProjectLink('')
-    setEditingProjectLabel('')
-    setEditingProjectOrder('')
-    setEditingProjectLogo('')
-  }
-
-  // Add fetch functions
-  const fetchProjects = async () => {
-    try {
-      const response = await getProjects()
-      setProjects(response)
-    } catch (error) {
-      console.error('Error fetching projects:', error)
-    }
-  }
-
   const fetchHeaders = async () => {
     try {
       const headersData = await getSectionHeaders()
@@ -346,10 +230,6 @@ export default function AdminActions() {
   }
 
   // Add useEffect to fetch data
-  useEffect(() => {
-    fetchProjects()
-  }, [])
-
   useEffect(() => {
     getSectionHeaders().then((response) => {
       setHeaders(response)
@@ -378,19 +258,6 @@ export default function AdminActions() {
     }
   }, [errorMessage])
 
-  const handleDeleteProject = async (id: string) => {
-    try {
-      await deleteProject(id)
-      await fetchProjects()
-      clearEditingProject()
-      setShowSuccess(true)
-      setSuccessMessage('Project deleted successfully!')
-    } catch (error) {
-      setShowError(true)
-      setErrorMessage('Failed to delete project.')
-    }
-  }
-
   const handleDeleteSection = async (id: string) => {
     try {
       await deleteSection(id)
@@ -412,143 +279,8 @@ export default function AdminActions() {
           onError={setErrorMessage}
         />
 
-        <div className="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40">
-          <h2 className="flex text-sm font-semibold text-zinc-900 dark:text-zinc-100">
-            Project Management
-          </h2>
-          <div className="mt-6">
-            <div>
-              <div className="flex items-center justify-end px-3">
-                <button
-                  onClick={() => {
-                    setShowAddProjectForm(true)
-                    clearAddProjectForm()
-                  }}
-                  className="w-32 px-3 py-2 text-sm font-semibold text-zinc-900 dark:text-zinc-100 hover:underline bg-transparent border-none shadow-none"
-                >
-                  Create
-                </button>
-              </div>
-              {projects.map((project, index) => (
-                <div 
-                  key={project.id} 
-                  className={`flex items-center justify-between px-3 ${
-                    index % 2 === 0 ? 'bg-zinc-50 dark:bg-zinc-800/50' : ''
-                  }`}
-                >
-                  <span>{project.name}</span>
-                  <button
-                    onClick={() => handleEditProject(project)}
-                    aria-label={`Edit ${project.name}`}
-                    className="w-32 px-3 py-2 text-sm font-semibold text-zinc-900 dark:text-zinc-100 hover:underline bg-transparent border-none shadow-none"
-                  >
-                    Edit
-                  </button>
-                </div>
-              ))}
-            </div>
-            {(editingProjectId || showAddProjectForm) && (
-              <form onSubmit={showAddProjectForm ? handleProjectSubmit : handleEditingProjectSubmit} className="mt-6 space-y-4">
-                <div>
-                  <label htmlFor="name" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Name
-                  </label>
-                  <input
-                    type="text"
-                    id="name"
-                    value={showAddProjectForm ? projectName : editingProjectName}
-                    onChange={(e) => showAddProjectForm ? setProjectName(e.target.value) : setEditingProjectName(e.target.value)}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div>
-                  <label htmlFor="description" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Description
-                  </label>
-                  <textarea
-                    id="description"
-                    value={showAddProjectForm ? projectDescription : editingProjectDescription}
-                    onChange={(e) => showAddProjectForm ? setProjectDescription(e.target.value) : setEditingProjectDescription(e.target.value)}
-                    rows={4}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div>
-                  <label htmlFor="link" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Link
-                  </label>
-                  <input
-                    type="text"
-                    id="link"
-                    value={showAddProjectForm ? projectLink : editingProjectLink}
-                    onChange={(e) => showAddProjectForm ? setProjectLink(e.target.value) : setEditingProjectLink(e.target.value)}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div>
-                  <label htmlFor="label" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Label
-                  </label>
-                  <input
-                    type="text"
-                    id="label"
-                    value={showAddProjectForm ? projectLabel : editingProjectLabel}
-                    onChange={(e) => showAddProjectForm ? setProjectLabel(e.target.value) : setEditingProjectLabel(e.target.value)}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div>
-                  <label htmlFor="logo" className="block text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                    Logo URL
-                  </label>
-                  <input
-                    type="text"
-                    id="logo"
-                    value={showAddProjectForm ? projectLogo : editingProjectLogo}
-                    onChange={(e) => showAddProjectForm ? setProjectLogo(e.target.value) : setEditingProjectLogo(e.target.value)}
-                    className="mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm"
-                  />
-                </div>
-                <div className="flex justify-between space-x-4">
-                  {editingProjectId && (
-                    <button
-                      type="button"
-                      onClick={async () => {
-                        if (window.confirm('Are you sure you want to delete this project?')) {
-                          await handleDeleteProject(editingProjectId)
-                        }
-                      }}
-                      className="rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-700"
-                    >
-                      Delete
-                    </button>
-                  )}
-                  <div className="flex space-x-4">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setShowAddProjectForm(false)
-                        clearAddProjectForm()
-                        clearEditingProject()
-                      }}
-                      className="rounded-md bg-zinc-200 px-3 py-2 text-sm font-semibold text-zinc-900 shadow-sm hover:bg-zinc-300 dark:bg-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-600"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      type="submit"
-                      className="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
-                    >
-                      {showAddProjectForm ? 'Add Project' : 'Update Project'}
-                    </button>
-                  </div>
-                </div>
-              </form>
-            )}
-          </div>
-        </div>
+        <ProjectManager onSuccess={setSuccessMessage} onError={setErrorMessage} />
 
-        {/* Edit Section Section */}
         <div className="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40">
           <h2 className="flex text-sm font-semibold text-zinc-900 dark:text-zinc-100">
             Section Management

--- a/src/app/services.test.ts
+++ b/src/app/services.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { updateSection } from './services'
+
+describe('updateSection', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }))
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('targets the /api/sections/[id] handler, not the ?id= one', async () => {
+    // The ?id= PATCH upserts contents with
+    //   `existingSection.contents[n]?.id || 'new'`
+    // and 'new' is not a valid ObjectId, so any section with fewer than three
+    // content rows fails to save. The [id] handler loops and creates instead.
+    await updateSection('abc', { title: 'T' })
+
+    const [url, init] = (fetch as any).mock.calls[0]
+    expect(url).toContain('/api/sections/abc')
+    expect(url).not.toContain('?id=')
+    expect(init.method).toBe('PATCH')
+  })
+
+  it('throws when the response is not ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) }))
+    await expect(updateSection('abc', {})).rejects.toThrow('Failed to update section')
+  })
+})

--- a/src/app/services.tsx
+++ b/src/app/services.tsx
@@ -65,7 +65,11 @@ export const createSection = async (section: any) => {
 }
 
 export const updateSection = async (sectionId: string, section: any) => {
-  const response = await fetch(createApiUrl(`/api/sections?id=${sectionId}`), {
+  // Uses the /api/sections/[id] handler rather than the ?id= one. The latter
+  // upserts contents with `existingSection.contents[n]?.id || 'new'`, and
+  // 'new' is not a valid ObjectId - so any section with fewer than three
+  // content rows fails to save.
+  const response = await fetch(createApiUrl(`/api/sections/${sectionId}`), {
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',

--- a/src/components/admin/ExperienceManager.test.tsx
+++ b/src/components/admin/ExperienceManager.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const svc = vi.hoisted(() => ({
+  getExperiences: vi.fn(),
+  createExperience: vi.fn(),
+  updateExperience: vi.fn(),
+  deleteExperience: vi.fn(),
+}))
+vi.mock('@/app/services', () => svc)
+
+import { ExperienceManager } from './ExperienceManager'
+
+const ROWS = [
+  { id: '1', title: 'Shipped a thing', date: '2025-03-10', content: 'Details here' },
+  { id: '2', title: 'Shipped another', date: '2024-01-02', content: 'More details' },
+]
+
+const onSuccess = vi.fn()
+const onError = vi.fn()
+
+function setup() {
+  render(<ExperienceManager onSuccess={onSuccess} onError={onError} />)
+  return userEvent.setup()
+}
+
+async function fillForm(user: ReturnType<typeof userEvent.setup>, v: Record<string, string>) {
+  for (const [label, value] of Object.entries(v)) {
+    const el = screen.getByLabelText(new RegExp(label, 'i'))
+    await user.clear(el)
+    if (value) await user.type(el, value)
+  }
+}
+
+describe('ExperienceManager', () => {
+  beforeEach(() => {
+    onSuccess.mockReset()
+    onError.mockReset()
+    svc.getExperiences.mockReset().mockResolvedValue(ROWS)
+    svc.createExperience.mockReset().mockResolvedValue({})
+    svc.updateExperience.mockReset().mockResolvedValue({})
+    svc.deleteExperience.mockReset().mockResolvedValue({})
+  })
+
+  it('lists existing experiences on mount', async () => {
+    setup()
+    expect(await screen.findByText('Shipped a thing')).toBeInTheDocument()
+    expect(screen.getByText('Shipped another')).toBeInTheDocument()
+  })
+
+  it('gives each row Edit button a distinguishing accessible name', async () => {
+    setup()
+    expect(await screen.findByRole('button', { name: 'Edit Shipped a thing' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit Shipped another' })).toBeInTheDocument()
+  })
+
+  it('creates an experience and refreshes the list', async () => {
+    const user = setup()
+    await screen.findByText('Shipped a thing')
+    await user.click(screen.getByRole('button', { name: 'Create' }))
+    await fillForm(user, { title: 'New one', 'date \\(yyyy': '2026-05-01', content: 'Body' })
+    await user.click(screen.getByRole('button', { name: 'Add Experience' }))
+
+    await waitFor(() =>
+      expect(svc.createExperience).toHaveBeenCalledWith({
+        title: 'New one', date: '2026-05-01', content: 'Body',
+      }),
+    )
+    expect(onSuccess).toHaveBeenCalledWith('Experience added successfully')
+    // Regression: the add path never re-fetched, so a newly created entry did
+    // not appear until a full page reload.
+    expect(svc.getExperiences).toHaveBeenCalledTimes(2)
+  })
+
+  it('opens the edit form prefilled and updates by id', async () => {
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Edit Shipped a thing' }))
+
+    expect(screen.getByLabelText(/title/i)).toHaveValue('Shipped a thing')
+    expect(screen.getByLabelText(/content/i)).toHaveValue('Details here')
+
+    await fillForm(user, { title: 'Renamed' })
+    await user.click(screen.getByRole('button', { name: 'Update Experience' }))
+
+    await waitFor(() =>
+      expect(svc.updateExperience).toHaveBeenCalledWith('1', {
+        title: 'Renamed', date: '2025-03-10', content: 'Details here',
+      }),
+    )
+    expect(onSuccess).toHaveBeenCalledWith('Experience updated successfully')
+  })
+
+  it('rejects empty fields without calling the API', async () => {
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Create' }))
+    await user.click(screen.getByRole('button', { name: 'Add Experience' }))
+
+    expect(onError).toHaveBeenCalledWith('All fields are required')
+    expect(svc.createExperience).not.toHaveBeenCalled()
+  })
+
+  it('rejects a malformed date', async () => {
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Create' }))
+    await fillForm(user, { title: 'T', 'date \\(yyyy': '05/01/2026', content: 'C' })
+    await user.click(screen.getByRole('button', { name: 'Add Experience' }))
+
+    expect(onError).toHaveBeenCalledWith('Invalid date format')
+    expect(svc.createExperience).not.toHaveBeenCalled()
+  })
+
+  it('reports an API failure instead of failing silently', async () => {
+    svc.createExperience.mockRejectedValue(new Error('boom'))
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Create' }))
+    await fillForm(user, { title: 'T', 'date \\(yyyy': '2026-05-01', content: 'C' })
+    await user.click(screen.getByRole('button', { name: 'Add Experience' }))
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith('Error adding experience'))
+  })
+
+  it('deletes only after the user confirms', async () => {
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Edit Shipped a thing' }))
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+    expect(svc.deleteExperience).not.toHaveBeenCalled()
+
+    confirm.mockReturnValue(true)
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+    await waitFor(() => expect(svc.deleteExperience).toHaveBeenCalledWith('1'))
+    expect(onSuccess).toHaveBeenCalledWith('Experience deleted successfully!')
+  })
+
+  it('closes the form on cancel', async () => {
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Create' }))
+    expect(screen.getByLabelText(/title/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(screen.queryByLabelText(/title/i)).not.toBeInTheDocument()
+  })
+
+  it('does not leak values from an edit into a later create', async () => {
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Edit Shipped a thing' }))
+    expect(screen.getByLabelText(/title/i)).toHaveValue('Shipped a thing')
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    await user.click(screen.getByRole('button', { name: 'Create' }))
+    expect(screen.getByLabelText(/title/i)).toHaveValue('')
+  })
+})

--- a/src/components/admin/ExperienceManager.tsx
+++ b/src/components/admin/ExperienceManager.tsx
@@ -1,0 +1,217 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+import {
+  createExperience,
+  deleteExperience,
+  getExperiences,
+  updateExperience,
+} from '@/app/services'
+
+export interface AdminExperience {
+  id: string
+  title: string
+  date: string
+  content: string
+}
+
+/**
+ * Which form, if any, is open. Replaces the previous pair of parallel state
+ * sets (`experienceTitle` + `editingExperienceTitle`, and so on) that every
+ * input had to choose between with a ternary.
+ */
+type Mode = { kind: 'closed' } | { kind: 'add' } | { kind: 'edit'; id: string }
+
+const EMPTY = { title: '', date: '', content: '' }
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/
+
+export function ExperienceManager({
+  onSuccess,
+  onError,
+}: {
+  onSuccess: (message: string) => void
+  onError: (message: string) => void
+}) {
+  const [experiences, setExperiences] = useState<AdminExperience[]>([])
+  const [mode, setMode] = useState<Mode>({ kind: 'closed' })
+  const [form, setForm] = useState(EMPTY)
+
+  const refresh = useCallback(async () => {
+    try {
+      setExperiences(await getExperiences())
+    } catch (error) {
+      console.error('Error fetching experiences:', error)
+    }
+  }, [])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const close = () => {
+    setMode({ kind: 'closed' })
+    setForm(EMPTY)
+  }
+
+  const field = (name: keyof typeof EMPTY) => ({
+    id: `experience-${name}`,
+    value: form[name],
+    onChange: (
+      e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    ) => setForm((f) => ({ ...f, [name]: e.target.value })),
+    className:
+      'mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm',
+  })
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (mode.kind === 'closed') return
+
+    if (!form.title || !form.date || !form.content) {
+      onError('All fields are required')
+      return
+    }
+    if (!ISO_DATE.test(form.date)) {
+      onError('Invalid date format')
+      return
+    }
+
+    const adding = mode.kind === 'add'
+    try {
+      if (adding) {
+        await createExperience(form)
+      } else {
+        await updateExperience(mode.id, form)
+      }
+      onSuccess(`Experience ${adding ? 'added' : 'updated'} successfully`)
+      close()
+      await refresh()
+    } catch (error) {
+      onError(`Error ${adding ? 'adding' : 'updating'} experience`)
+      console.error('Error:', error)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (mode.kind !== 'edit') return
+    if (!window.confirm('Are you sure you want to delete this experience?')) return
+
+    try {
+      await deleteExperience(mode.id)
+      close()
+      await refresh()
+      onSuccess('Experience deleted successfully!')
+    } catch (error) {
+      onError('Failed to delete experience.')
+    }
+  }
+
+  const buttonClass =
+    'w-32 px-3 py-2 text-sm font-semibold text-zinc-900 dark:text-zinc-100 hover:underline bg-transparent border-none shadow-none'
+
+  return (
+    <div className="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40">
+      <h2 className="flex text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+        Experience Management
+      </h2>
+      <div className="mt-6">
+        <div>
+          <div className="flex items-center justify-end px-3">
+            <button
+              onClick={() => {
+                setForm(EMPTY)
+                setMode({ kind: 'add' })
+              }}
+              className={buttonClass}
+            >
+              Create
+            </button>
+          </div>
+          {experiences.map((experience, index) => (
+            <div
+              key={experience.id}
+              className={`flex items-center justify-between px-3 ${
+                index % 2 === 0 ? 'bg-zinc-50 dark:bg-zinc-800/50' : ''
+              }`}
+            >
+              <span>{experience.title}</span>
+              <button
+                onClick={() => {
+                  setForm({
+                    title: experience.title,
+                    date: experience.date,
+                    content: experience.content,
+                  })
+                  setMode({ kind: 'edit', id: experience.id })
+                }}
+                aria-label={`Edit ${experience.title}`}
+                className={buttonClass}
+              >
+                Edit
+              </button>
+            </div>
+          ))}
+        </div>
+
+        {mode.kind !== 'closed' && (
+          <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+            <div>
+              <label
+                htmlFor="experience-title"
+                className="block text-sm font-medium text-zinc-900 dark:text-zinc-100"
+              >
+                Title
+              </label>
+              <input type="text" {...field('title')} />
+            </div>
+            <div>
+              <label
+                htmlFor="experience-date"
+                className="block text-sm font-medium text-zinc-900 dark:text-zinc-100"
+              >
+                Date (YYYY-MM-DD)
+              </label>
+              <input type="text" {...field('date')} />
+            </div>
+            <div>
+              <label
+                htmlFor="experience-content"
+                className="block text-sm font-medium text-zinc-900 dark:text-zinc-100"
+              >
+                Content
+              </label>
+              <textarea rows={4} {...field('content')} />
+            </div>
+            <div className="flex justify-between space-x-4">
+              {mode.kind === 'edit' && (
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  className="rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-700"
+                >
+                  Delete
+                </button>
+              )}
+              <div className="flex space-x-4">
+                <button
+                  type="button"
+                  onClick={close}
+                  className="rounded-md bg-zinc-200 px-3 py-2 text-sm font-semibold text-zinc-900 shadow-sm hover:bg-zinc-300 dark:bg-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-600"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+                >
+                  {mode.kind === 'add' ? 'Add Experience' : 'Update Experience'}
+                </button>
+              </div>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/ProjectManager.test.tsx
+++ b/src/components/admin/ProjectManager.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const svc = vi.hoisted(() => ({
+  getProjects: vi.fn(),
+  createProject: vi.fn(),
+  updateProject: vi.fn(),
+  deleteProject: vi.fn(),
+}))
+vi.mock('@/app/services', () => svc)
+
+import { ProjectManager } from './ProjectManager'
+
+const ROWS = [
+  { id: 'p1', name: 'Portfolio', description: 'This site', link: 'https://a', label: 'Github Link', order: 0, logo: '' },
+  { id: 'p2', name: 'Allegiance', description: 'Client work', link: 'https://b', label: 'Website Link', order: 1, logo: '' },
+]
+
+const onSuccess = vi.fn()
+const onError = vi.fn()
+
+function setup() {
+  render(<ProjectManager onSuccess={onSuccess} onError={onError} />)
+  return userEvent.setup()
+}
+
+describe('ProjectManager', () => {
+  beforeEach(() => {
+    onSuccess.mockReset(); onError.mockReset()
+    svc.getProjects.mockReset().mockResolvedValue(ROWS)
+    svc.createProject.mockReset().mockResolvedValue({})
+    svc.updateProject.mockReset().mockResolvedValue({})
+    svc.deleteProject.mockReset().mockResolvedValue({})
+  })
+
+  it('lists projects with distinguishable Edit buttons', async () => {
+    setup()
+    expect(await screen.findByRole('button', { name: 'Edit Portfolio' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit Allegiance' })).toBeInTheDocument()
+  })
+
+  it('prefills the order field when editing', async () => {
+    // Regression: handleEditProject never populated editingProjectOrder, and
+    // the form had no order input at all, so the value was unrecoverable.
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Edit Allegiance' }))
+    expect(screen.getByLabelText(/order/i)).toHaveValue(1)
+  })
+
+  it('preserves an existing order when editing other fields', async () => {
+    // Regression: `parseInt(editingProjectOrder) || 0` reset every edited
+    // project to order 0, silently destroying a deliberate ordering.
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Edit Allegiance' }))
+    const name = screen.getByLabelText(/name/i)
+    await user.clear(name)
+    await user.type(name, 'Allegiance HHC')
+    await user.click(screen.getByRole('button', { name: 'Update Project' }))
+
+    await waitFor(() =>
+      expect(svc.updateProject).toHaveBeenCalledWith(
+        'p2', expect.objectContaining({ name: 'Allegiance HHC', order: 1 }),
+      ),
+    )
+  })
+
+  it('keeps the current order when the box is cleared', async () => {
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Edit Allegiance' }))
+    await user.clear(screen.getByLabelText(/order/i))
+    await user.click(screen.getByRole('button', { name: 'Update Project' }))
+
+    await waitFor(() =>
+      expect(svc.updateProject).toHaveBeenCalledWith('p2', expect.objectContaining({ order: 1 })),
+    )
+  })
+
+  it('puts a new project at the end rather than sending null', async () => {
+    // Regression: parseInt('') is NaN, which JSON.stringify turns into null.
+    // That is how three of four live projects ended up with order: null.
+    const user = setup()
+    await screen.findByText('Portfolio')
+    await user.click(screen.getByRole('button', { name: 'Create' }))
+    for (const [label, value] of [[/name/i, 'New'], [/description/i, 'D'], [/link/i, 'https://c'], [/^label$/i, 'L']] as const) {
+      await user.type(screen.getByLabelText(label), value)
+    }
+    await user.click(screen.getByRole('button', { name: 'Add Project' }))
+
+    await waitFor(() =>
+      expect(svc.createProject).toHaveBeenCalledWith(expect.objectContaining({ name: 'New', order: 2 })),
+    )
+    expect(onSuccess).toHaveBeenCalledWith('Project added successfully')
+    expect(svc.getProjects).toHaveBeenCalledTimes(2) // list refreshes after add
+  })
+
+  it('honours an explicitly typed order', async () => {
+    const user = setup()
+    await screen.findByText('Portfolio')
+    await user.click(screen.getByRole('button', { name: 'Create' }))
+    for (const [label, value] of [[/name/i, 'N'], [/description/i, 'D'], [/link/i, 'https://c'], [/^label$/i, 'L']] as const) {
+      await user.type(screen.getByLabelText(label), value)
+    }
+    await user.type(screen.getByLabelText(/order/i), '7')
+    await user.click(screen.getByRole('button', { name: 'Add Project' }))
+
+    await waitFor(() =>
+      expect(svc.createProject).toHaveBeenCalledWith(expect.objectContaining({ order: 7 })),
+    )
+  })
+
+  it('rejects missing required fields without calling the API', async () => {
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Create' }))
+    await user.click(screen.getByRole('button', { name: 'Add Project' }))
+    expect(onError).toHaveBeenCalledWith('All fields are required')
+    expect(svc.createProject).not.toHaveBeenCalled()
+  })
+
+  it('reports API failures', async () => {
+    svc.updateProject.mockRejectedValue(new Error('nope'))
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Edit Portfolio' }))
+    await user.click(screen.getByRole('button', { name: 'Update Project' }))
+    await waitFor(() => expect(onError).toHaveBeenCalledWith('Error updating project'))
+  })
+
+  it('deletes only after confirmation', async () => {
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Edit Portfolio' }))
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+    expect(svc.deleteProject).not.toHaveBeenCalled()
+
+    confirm.mockReturnValue(true)
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+    await waitFor(() => expect(svc.deleteProject).toHaveBeenCalledWith('p1'))
+  })
+})

--- a/src/components/admin/ProjectManager.tsx
+++ b/src/components/admin/ProjectManager.tsx
@@ -1,0 +1,244 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+import {
+  createProject,
+  deleteProject,
+  getProjects,
+  updateProject,
+} from '@/app/services'
+
+export interface AdminProject {
+  id: string
+  name: string
+  description: string
+  link: string
+  label: string
+  order?: number | null
+  logo?: string | null
+}
+
+type Mode = { kind: 'closed' } | { kind: 'add' } | { kind: 'edit'; id: string }
+
+const EMPTY = { name: '', description: '', link: '', label: '', order: '', logo: '' }
+type Form = typeof EMPTY
+
+export function ProjectManager({
+  onSuccess,
+  onError,
+}: {
+  onSuccess: (message: string) => void
+  onError: (message: string) => void
+}) {
+  const [projects, setProjects] = useState<AdminProject[]>([])
+  const [mode, setMode] = useState<Mode>({ kind: 'closed' })
+  const [form, setForm] = useState<Form>(EMPTY)
+
+  const refresh = useCallback(async () => {
+    try {
+      setProjects(await getProjects())
+    } catch (error) {
+      console.error('Error fetching projects:', error)
+    }
+  }, [])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const close = () => {
+    setMode({ kind: 'closed' })
+    setForm(EMPTY)
+  }
+
+  /**
+   * `order` drives the sort on /projects. A blank box must never be written as
+   * NaN (which serialises to null) or silently coerced to 0 - both of those
+   * discard a deliberate ordering. Blank means "leave it where it is", and a
+   * brand new project goes on the end.
+   */
+  const resolveOrder = (): number => {
+    const typed = parseInt(form.order, 10)
+    if (!Number.isNaN(typed)) return typed
+    if (mode.kind === 'edit') {
+      const current = projects.find((p) => p.id === mode.id)?.order
+      if (typeof current === 'number') return current
+    }
+    const highest = projects.reduce(
+      (max, p) => (typeof p.order === 'number' && p.order > max ? p.order : max),
+      -1,
+    )
+    return highest + 1
+  }
+
+  const field = (name: keyof Form) => ({
+    id: `project-${name}`,
+    value: form[name],
+    onChange: (
+      e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    ) => setForm((f) => ({ ...f, [name]: e.target.value })),
+    className:
+      'mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm',
+  })
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (mode.kind === 'closed') return
+
+    if (!form.name || !form.description || !form.link || !form.label) {
+      onError('All fields are required')
+      return
+    }
+
+    const payload = {
+      name: form.name,
+      description: form.description,
+      link: form.link,
+      label: form.label,
+      order: resolveOrder(),
+      logo: form.logo,
+    }
+
+    const adding = mode.kind === 'add'
+    try {
+      if (adding) {
+        await createProject(payload)
+      } else {
+        await updateProject(mode.id, payload)
+      }
+      onSuccess(`Project ${adding ? 'added' : 'updated'} successfully`)
+      close()
+      await refresh()
+    } catch (error) {
+      onError(`Error ${adding ? 'adding' : 'updating'} project`)
+      console.error('Error:', error)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (mode.kind !== 'edit') return
+    if (!window.confirm('Are you sure you want to delete this project?')) return
+
+    try {
+      await deleteProject(mode.id)
+      close()
+      await refresh()
+      onSuccess('Project deleted successfully!')
+    } catch (error) {
+      onError('Failed to delete project.')
+    }
+  }
+
+  const rowButton =
+    'w-32 px-3 py-2 text-sm font-semibold text-zinc-900 dark:text-zinc-100 hover:underline bg-transparent border-none shadow-none'
+  const labelClass =
+    'block text-sm font-medium text-zinc-900 dark:text-zinc-100'
+
+  return (
+    <div className="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40">
+      <h2 className="flex text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+        Project Management
+      </h2>
+      <div className="mt-6">
+        <div>
+          <div className="flex items-center justify-end px-3">
+            <button
+              onClick={() => {
+                setForm(EMPTY)
+                setMode({ kind: 'add' })
+              }}
+              className={rowButton}
+            >
+              Create
+            </button>
+          </div>
+          {projects.map((project, index) => (
+            <div
+              key={project.id}
+              className={`flex items-center justify-between px-3 ${
+                index % 2 === 0 ? 'bg-zinc-50 dark:bg-zinc-800/50' : ''
+              }`}
+            >
+              <span>{project.name}</span>
+              <button
+                onClick={() => {
+                  setForm({
+                    name: project.name,
+                    description: project.description,
+                    link: project.link,
+                    label: project.label,
+                    order: typeof project.order === 'number' ? String(project.order) : '',
+                    logo: project.logo ?? '',
+                  })
+                  setMode({ kind: 'edit', id: project.id })
+                }}
+                aria-label={`Edit ${project.name}`}
+                className={rowButton}
+              >
+                Edit
+              </button>
+            </div>
+          ))}
+        </div>
+
+        {mode.kind !== 'closed' && (
+          <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+            <div>
+              <label htmlFor="project-name" className={labelClass}>Name</label>
+              <input type="text" {...field('name')} />
+            </div>
+            <div>
+              <label htmlFor="project-description" className={labelClass}>Description</label>
+              <textarea rows={4} {...field('description')} />
+            </div>
+            <div>
+              <label htmlFor="project-link" className={labelClass}>Link</label>
+              <input type="text" {...field('link')} />
+            </div>
+            <div>
+              <label htmlFor="project-label" className={labelClass}>Label</label>
+              <input type="text" {...field('label')} />
+            </div>
+            <div>
+              <label htmlFor="project-order" className={labelClass}>
+                Order (lowest first; blank keeps the current position)
+              </label>
+              <input type="number" {...field('order')} />
+            </div>
+            <div>
+              <label htmlFor="project-logo" className={labelClass}>Logo</label>
+              <input type="text" {...field('logo')} />
+            </div>
+            <div className="flex justify-between space-x-4">
+              {mode.kind === 'edit' && (
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  className="rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-700"
+                >
+                  Delete
+                </button>
+              )}
+              <div className="flex space-x-4">
+                <button
+                  type="button"
+                  onClick={close}
+                  className="rounded-md bg-zinc-200 px-3 py-2 text-sm font-semibold text-zinc-900 shadow-sm hover:bg-zinc-300 dark:bg-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-600"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+                >
+                  {mode.kind === 'add' ? 'Add Project' : 'Update Project'}
+                </button>
+              </div>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/SectionManager.test.tsx
+++ b/src/components/admin/SectionManager.test.tsx
@@ -1,0 +1,162 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const svc = vi.hoisted(() => ({
+  getSectionHeaders: vi.fn(),
+  getSectionById: vi.fn(),
+  createSection: vi.fn(),
+  updateSection: vi.fn(),
+  deleteSection: vi.fn(),
+}))
+vi.mock('@/app/services', () => svc)
+
+import { SectionManager } from './SectionManager'
+
+const HEADERS = [
+  { id: 's1', header: 'Development' },
+  { id: 's2', header: 'College' },
+]
+
+const COLLEGE = {
+  id: 's2', title: 'Education', order: 9, header: 'College', subHeader: 'Degrees',
+  contents: [{ content: 'MBA' }, { content: 'BS' }], // only two - see the route note
+}
+
+const onSuccess = vi.fn()
+const onError = vi.fn()
+
+function setup() {
+  render(<SectionManager onSuccess={onSuccess} onError={onError} />)
+  return userEvent.setup()
+}
+
+describe('SectionManager', () => {
+  beforeEach(() => {
+    onSuccess.mockReset(); onError.mockReset()
+    svc.getSectionHeaders.mockReset().mockResolvedValue(HEADERS)
+    svc.getSectionById.mockReset().mockResolvedValue(COLLEGE)
+    svc.createSection.mockReset().mockResolvedValue({})
+    svc.updateSection.mockReset().mockResolvedValue({})
+    svc.deleteSection.mockReset().mockResolvedValue({})
+  })
+
+  it('lists section headers with distinguishable Edit buttons', async () => {
+    setup()
+    expect(await screen.findByRole('button', { name: 'Edit Development' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Edit College' })).toBeInTheDocument()
+  })
+
+  it('loads a section through the service layer and prefills every field', async () => {
+    // Previously this used a hardcoded fetch('/api/sections/${id}') with no
+    // response check, bypassing the service layer entirely.
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Edit College' }))
+
+    await waitFor(() => expect(svc.getSectionById).toHaveBeenCalledWith('s2'))
+    expect(screen.getByLabelText(/^title/i)).toHaveValue('Education')
+    expect(screen.getByLabelText(/^header$/i)).toHaveValue('College')
+    expect(screen.getByLabelText(/sub header/i)).toHaveValue('Degrees')
+    expect(screen.getByLabelText(/order/i)).toHaveValue(9)
+    expect(screen.getByLabelText(/content 1/i)).toHaveValue('MBA')
+    expect(screen.getByLabelText(/content 2/i)).toHaveValue('BS')
+    expect(screen.getByLabelText(/content 3/i)).toHaveValue('')
+  })
+
+  it('exposes subHeader for editing', async () => {
+    // Regression: subHeader was stored and sent but had no input, so it could
+    // only ever be set through the API. Sections with a blank subHeader are
+    // what produced the empty <h3> elements on /resume.
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Edit College' }))
+    const sub = await screen.findByLabelText(/sub header/i)
+    await user.clear(sub)
+    await user.type(sub, 'Education history')
+    await user.click(screen.getByRole('button', { name: 'Update Section' }))
+
+    await waitFor(() =>
+      expect(svc.updateSection).toHaveBeenCalledWith(
+        's2', expect.objectContaining({ subHeader: 'Education history' }),
+      ),
+    )
+  })
+
+  it('sends the flattened content1..3 shape on update', async () => {
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Edit College' }))
+    await screen.findByLabelText(/content 1/i)
+    await user.click(screen.getByRole('button', { name: 'Update Section' }))
+
+    await waitFor(() =>
+      expect(svc.updateSection).toHaveBeenCalledWith('s2', expect.objectContaining({
+        content1: 'MBA', content2: 'BS', content3: '', order: 9,
+      })),
+    )
+    expect(onSuccess).toHaveBeenCalledWith('Section updated successfully')
+  })
+
+  it('sends the nested contents.records shape on create', async () => {
+    const user = setup()
+    await screen.findByText('Development')
+    await user.click(screen.getByRole('button', { name: 'Create' }))
+    await user.type(screen.getByLabelText(/^title/i), 'Education')
+    await user.type(screen.getByLabelText(/^header$/i), 'Bootcamps')
+    await user.type(screen.getByLabelText(/content 1/i), 'First')
+    await user.click(screen.getByRole('button', { name: 'Add Section' }))
+
+    await waitFor(() =>
+      expect(svc.createSection).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'Education',
+        header: 'Bootcamps',
+        contents: { records: [
+          { content: 'First', order: 0 },
+          { content: '', order: 1 },
+          { content: '', order: 2 },
+        ] },
+      })),
+    )
+  })
+
+  it('never writes a NaN order when the box is blank', async () => {
+    // parseInt('') is NaN, which JSON.stringify turns into null.
+    const user = setup()
+    await screen.findByText('Development')
+    await user.click(screen.getByRole('button', { name: 'Create' }))
+    await user.type(screen.getByLabelText(/^title/i), 'T')
+    await user.type(screen.getByLabelText(/^header$/i), 'H')
+    await user.click(screen.getByRole('button', { name: 'Add Section' }))
+
+    await waitFor(() => expect(svc.createSection).toHaveBeenCalled())
+    const { order } = svc.createSection.mock.calls[0][0]
+    expect(Number.isNaN(order)).toBe(false)
+    expect(order).toBe(0)
+  })
+
+  it('requires a title and a header', async () => {
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Create' }))
+    await user.click(screen.getByRole('button', { name: 'Add Section' }))
+    expect(onError).toHaveBeenCalledWith('Title and Header are required')
+    expect(svc.createSection).not.toHaveBeenCalled()
+  })
+
+  it('reports a failure to load a section instead of silently doing nothing', async () => {
+    svc.getSectionById.mockRejectedValue(new Error('boom'))
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Edit College' }))
+    await waitFor(() => expect(onError).toHaveBeenCalledWith('Error fetching section'))
+  })
+
+  it('deletes only after confirmation', async () => {
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const user = setup()
+    await user.click(await screen.findByRole('button', { name: 'Edit College' }))
+    await screen.findByLabelText(/content 1/i)
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+    expect(svc.deleteSection).not.toHaveBeenCalled()
+
+    confirm.mockReturnValue(true)
+    await user.click(screen.getByRole('button', { name: 'Delete' }))
+    await waitFor(() => expect(svc.deleteSection).toHaveBeenCalledWith('s2'))
+  })
+})

--- a/src/components/admin/SectionManager.tsx
+++ b/src/components/admin/SectionManager.tsx
@@ -1,0 +1,264 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+import {
+  createSection,
+  deleteSection,
+  getSectionById,
+  getSectionHeaders,
+  updateSection,
+} from '@/app/services'
+import { type Header } from '@/lib/resume'
+
+type Mode = { kind: 'closed' } | { kind: 'add' } | { kind: 'edit'; id: string }
+
+const EMPTY = {
+  title: '',
+  order: '',
+  header: '',
+  subHeader: '',
+  content1: '',
+  content2: '',
+  content3: '',
+}
+type Form = typeof EMPTY
+
+/**
+ * Sections are still modelled as exactly three content slots, because both the
+ * create and update endpoints are shaped that way (`contents.records` on POST,
+ * `content1..3` on PATCH). Generalising to a list is a server change as much as
+ * a client one, so this component preserves the existing contract.
+ */
+export function SectionManager({
+  onSuccess,
+  onError,
+}: {
+  onSuccess: (message: string) => void
+  onError: (message: string) => void
+}) {
+  const [headers, setHeaders] = useState<Header[]>([])
+  const [mode, setMode] = useState<Mode>({ kind: 'closed' })
+  const [form, setForm] = useState<Form>(EMPTY)
+
+  const refresh = useCallback(async () => {
+    try {
+      setHeaders(await getSectionHeaders())
+    } catch (error) {
+      onError('Failed to fetch section headers.')
+    }
+  }, [onError])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const close = () => {
+    setMode({ kind: 'closed' })
+    setForm(EMPTY)
+  }
+
+  /** Blank must not become NaN (which serialises to null) or silently 0. */
+  const resolveOrder = (): number => {
+    const typed = parseInt(form.order, 10)
+    if (!Number.isNaN(typed)) return typed
+    const highest = headers.reduce(
+      (max, h: any) => (typeof h.order === 'number' && h.order > max ? h.order : max),
+      -1,
+    )
+    return highest + 1
+  }
+
+  const openForEdit = async (id: string) => {
+    try {
+      const data: any = await getSectionById(id)
+      setForm({
+        title: data.title ?? '',
+        order: typeof data.order === 'number' ? String(data.order) : '',
+        header: data.header ?? '',
+        subHeader: data.subHeader ?? '',
+        content1: data.contents?.[0]?.content ?? '',
+        content2: data.contents?.[1]?.content ?? '',
+        content3: data.contents?.[2]?.content ?? '',
+      })
+      setMode({ kind: 'edit', id })
+    } catch (error) {
+      onError('Error fetching section')
+      console.error('Error fetching section:', error)
+    }
+  }
+
+  const field = (name: keyof Form) => ({
+    id: `section-${name}`,
+    value: form[name],
+    onChange: (
+      e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    ) => setForm((f) => ({ ...f, [name]: e.target.value })),
+    className:
+      'mt-1 block w-full rounded-md border-zinc-300 shadow-sm focus:border-zinc-500 focus:ring-zinc-500 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-100 sm:text-sm',
+  })
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (mode.kind === 'closed') return
+
+    if (!form.title || !form.header) {
+      onError('Title and Header are required')
+      return
+    }
+
+    const adding = mode.kind === 'add'
+    try {
+      if (adding) {
+        // POST expects nested `contents.records`.
+        await createSection({
+          title: form.title,
+          order: resolveOrder(),
+          header: form.header,
+          subHeader: form.subHeader,
+          contents: {
+            records: [
+              { content: form.content1, order: 0 },
+              { content: form.content2, order: 1 },
+              { content: form.content3, order: 2 },
+            ],
+          },
+        })
+      } else {
+        // PATCH expects flattened content1..3.
+        await updateSection(mode.id, {
+          title: form.title,
+          order: resolveOrder(),
+          header: form.header,
+          subHeader: form.subHeader,
+          content1: form.content1,
+          content2: form.content2,
+          content3: form.content3,
+        })
+      }
+      onSuccess(`Section ${adding ? 'added' : 'updated'} successfully`)
+      close()
+      await refresh()
+    } catch (error) {
+      onError(`Error ${adding ? 'adding' : 'updating'} section`)
+      console.error('Error:', error)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (mode.kind !== 'edit') return
+    if (!window.confirm('Are you sure you want to delete this section?')) return
+
+    try {
+      await deleteSection(mode.id)
+      close()
+      await refresh()
+      onSuccess('Section deleted successfully!')
+    } catch (error) {
+      onError('Failed to delete section.')
+    }
+  }
+
+  const rowButton =
+    'w-32 px-3 py-2 text-sm font-semibold text-zinc-900 dark:text-zinc-100 hover:underline bg-transparent border-none shadow-none'
+  const labelClass = 'block text-sm font-medium text-zinc-900 dark:text-zinc-100'
+
+  return (
+    <div className="rounded-2xl border border-zinc-100 p-6 dark:border-zinc-700/40">
+      <h2 className="flex text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+        Section Management
+      </h2>
+      <div className="mt-6">
+        <div>
+          <div className="flex items-center justify-end px-3">
+            <button
+              onClick={() => {
+                setForm(EMPTY)
+                setMode({ kind: 'add' })
+              }}
+              className={rowButton}
+            >
+              Create
+            </button>
+          </div>
+          {headers.map((header, index) => (
+            <div
+              key={header.id}
+              className={`flex items-center px-3 ${
+                (index + 1) % 2 === 0 ? 'bg-zinc-50 dark:bg-zinc-800/50' : ''
+              }`}
+            >
+              <span className="flex-1">{header.header}</span>
+              <button
+                onClick={() => openForEdit(header.id)}
+                aria-label={`Edit ${header.header}`}
+                className={rowButton}
+              >
+                Edit
+              </button>
+            </div>
+          ))}
+        </div>
+
+        {mode.kind !== 'closed' && (
+          <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+            <div>
+              <label htmlFor="section-title" className={labelClass}>
+                Title (groups sections on the resume page)
+              </label>
+              <input type="text" {...field('title')} />
+            </div>
+            <div>
+              <label htmlFor="section-order" className={labelClass}>
+                Order (lowest first; blank appends)
+              </label>
+              <input type="number" {...field('order')} />
+            </div>
+            <div>
+              <label htmlFor="section-header" className={labelClass}>Header</label>
+              <input type="text" {...field('header')} />
+            </div>
+            <div>
+              <label htmlFor="section-subHeader" className={labelClass}>Sub Header</label>
+              <input type="text" {...field('subHeader')} />
+            </div>
+            {(['content1', 'content2', 'content3'] as const).map((name, i) => (
+              <div key={name}>
+                <label htmlFor={`section-${name}`} className={labelClass}>
+                  {`Content ${i + 1}`}
+                </label>
+                <textarea rows={3} {...field(name)} />
+              </div>
+            ))}
+            <div className="flex justify-between space-x-4">
+              {mode.kind === 'edit' && (
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  className="rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-700"
+                >
+                  Delete
+                </button>
+              )}
+              <div className="flex space-x-4">
+                <button
+                  type="button"
+                  onClick={close}
+                  className="rounded-md bg-zinc-200 px-3 py-2 text-sm font-semibold text-zinc-900 shadow-sm hover:bg-zinc-300 dark:bg-zinc-700 dark:text-zinc-100 dark:hover:bg-zinc-600"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+                >
+                  {mode.kind === 'add' ? 'Add Section' : 'Update Section'}
+                </button>
+              </div>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
**Replaces #23, #24 and #25.** Those were stacked on each other rather than on `main`, so merging them landed the commits in their *base branches* — none of the refactor reached `main`. This is the same three commits rebased onto current `main` as one reviewable branch.

```
admin/page.tsx   949 → 130 lines,   46 → 5 useState
```

The page is now a shell: three panel components plus the notification state they report into.

## The three commits

| Commit | What |
|---|---|
| `ExperienceManager` | 9 state vars, 6 handlers, 113 lines of JSX |
| `ProjectManager` | 15 state vars, fixes two `order` bugs |
| `SectionManager` | 17 state vars, fixes a broken save path |

Each replaces two parallel state sets with one `form` object and a discriminated `closed \| add \| edit` mode, so every input stops doing this:

```jsx
value={showAddProjectForm ? projectName : editingProjectName}
```

## Bugs fixed along the way

**Projects had no Order input at all**, yet the handlers read `projectOrder`/`editingProjectOrder`:
- Creating wrote `order: null` (`parseInt('')` → `NaN` → `null`). That's how three of your four projects ended up null.
- Editing reset order to `0` — so opening any project and saving it silently discarded its position, undoing the ordering set in #19.

**Sections with fewer than three content rows could not be saved.** `updateSection()` hit `PATCH /api/sections?id=`, which upserts with `contents[n]?.id || 'new'` — and `'new'` isn't a valid ObjectId. Your **College** section has two rows (I deleted an empty third while applying résumé content), so editing it would have failed. Now routed to the `/api/sections/[id]` handler, which creates missing rows instead.

**`subHeader` had no input** — stored, loaded and sent, but only settable via the API. That's the root cause of the empty `<h3>` elements on `/resume` that #20 fixed at the render layer.

Also: the create path never re-fetched in Experience and Project, so new entries didn't appear until a page reload.

## Tests — 30 new, 47 total

10 for Experience, 9 for Project, 9 for Section, 2 pinning `updateSection`'s route so the broken handler can't be reinstated silently.

## Deliberately unchanged

Sections are still exactly three content slots — both endpoints are shaped that way (`contents.records` on POST, `content1..3` on PATCH), so generalising is a server change too. The now-unused `?id=` PATCH handler could also be deleted, but that's its own PR.

## Verification

```
Test Files  9 passed (9)
     Tests  47 passed (47)
```

`next build` exit 0 · `tsc --noEmit` 0 errors · `next lint --max-warnings=0` clean

## Merge order

Independent of #26 (different files), so either order works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)