### PR TITLE
Drop the performance and accessibility sentence from the home page bio

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -140,8 +140,7 @@ export default async function Home() {
             I&apos;m DeRon, a software engineer based in St. Louis. At Omni
             Federal I build full-stack applications for federal geospatial
             workflows; before that I spent three years at AT&amp;T on internal
-            tools used across the company. I care about performance and
-            accessibility, and I measure both rather than assuming.
+            tools used across the company.
           </p>
           <div className="mt-6 flex gap-6">
             <SocialLink


### PR DESCRIPTION
Removes the closing sentence of the home page intro paragraph:

> I care about performance and accessibility, and I measure both rather than assuming.

The paragraph now ends on `tools used across the company.`

The text lived in `src/app/page.tsx`, not in MongoDB, so this is a source change rather than a content edit through the admin UI.

Verified `npx prettier --check`, and `npm run build` passes. Note that `npx tsc --noEmit` reports three pre-existing `TS2307` errors for image imports; those come from `next-env.d.ts` not being generated outside a build and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019xDMoR6R4y1wpjGGLQj9Ek