### PR TITLE
fix: ship bcrypt's native binary in the standalone bundle

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,6 +16,13 @@ const nextConfig = {
     // Enables src/instrumentation.ts, which fails the boot when SESSION_SECRET
     // is missing rather than letting the server come up without it.
     instrumentationHook: true,
+    // bcrypt loads its .node binary at runtime through node-gyp-build, which
+    // static tracing cannot follow, so the standalone bundle ships the JS
+    // wrapper without the native build and every call throws. Name the
+    // prebuilds explicitly for the one route that hashes passwords.
+    outputFileTracingIncludes: {
+      '/api/users': ['./node_modules/bcrypt/prebuilds/**'],
+    },
   },
   // Add output configuration
   output: 'standalone',


### PR DESCRIPTION
Login returns **500 for every request** in production right now. This is not a credentials problem — the route crashes before it compares anything.

## Cause

`bcrypt` resolves its `.node` binary at runtime through `node-gyp-build`. Next's `output: 'standalone'` traces imports statically and can't follow that, so `.next/standalone/node_modules/bcrypt` shipped `bcrypt.js`, `package.json` and `promises.js` — but no `prebuilds/`. Every request to `/api/users?path=login` threw on module load:

```
Error: No native build was found for platform=linux arch=x64
runtime=node abi=127 uv=1 libc=glibc node=22.11.0
  loaded from: /app/.next/standalone/node_modules/bcrypt
```

`/app/node_modules/bcrypt/prebuilds/linux-x64/` did have the binary, but the standalone tree shadows it.

## Fix

`outputFileTracingIncludes` names the prebuilds explicitly for the one route that hashes passwords.

## Verification

- Rebuilt; confirmed `prebuilds/linux-x64/bcrypt.glibc.node` is now in the bundle.
- Loaded that bundled copy under `node:22-bookworm` — the runtime the Nixpacks build actually uses — and ran `bcrypt.compare` against the stored hash in the production database. Loads clean, returns `true`.

## Note for a separate change

The repo's `Dockerfile` is not used by this deploy. Coolify builds with Nixpacks (Node 22.11.0, glibc, `node .next/standalone/server.js`), while the Dockerfile pins `node:20-alpine` and `npm start`. Its OpenSSL setup, `prisma generate` step and Node version have no effect on production. Worth reconciling — a Dockerfile that looks authoritative but isn't will mislead again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgA5fWoxPxaTXfin9L5QvK